### PR TITLE
Add manual instrumentation for consistent "problem domain" actions in the various implementations

### DIFF
--- a/golang/frontend/main.go
+++ b/golang/frontend/main.go
@@ -70,10 +70,18 @@ func main() {
 }
 
 func getName(ctx context.Context) string {
+	tracer := global.Tracer("greeting-service/frontend")
+	var getNameSpan trace.Span
+  ctx, getNameSpan = tracer.Start(ctx, "name retrieval")
+  defer getNameSpan.End()
 	return makeRequest(ctx, nameServiceUrl)
 }
 
 func getMessage(ctx context.Context) string {
+	tracer := global.Tracer("greeting-service/frontend")
+	var getMessageSpan trace.Span
+  ctx, getMessageSpan = tracer.Start(ctx, "message retrieval")
+  defer getMessageSpan.End()
 	return makeRequest(ctx, messageServiceUrl)
 }
 

--- a/python/frontend/frontend/__init__.py
+++ b/python/frontend/frontend/__init__.py
@@ -4,6 +4,7 @@ from werkzeug.routing import Map, Rule
 from werkzeug.wrappers import Request, Response
 from http.client import HTTPException
 
+import beeline
 from beeline.patch import urllib
 import urllib
 
@@ -28,10 +29,12 @@ class Greeting(object):
         except HTTPException as e:
             return e
 
+    @beeline.traced(name="name retrieval")
     def get_name(self):
         with urllib.request.urlopen('http://localhost:8000/name') as f:
             return f.read().decode('utf-8')
 
+    @beeline.traced(name="message retrieval")
     def get_message(self):
         with urllib.request.urlopen('http://localhost:9000/message') as f:
             return f.read().decode('utf-8')

--- a/ruby/frontend/frontend.ru
+++ b/ruby/frontend/frontend.ru
@@ -66,17 +66,21 @@ end
 
 class NameClient
   def self.get_name
-    Faraday.new("http://localhost:8000")
-           .get("/name")
-           .body
+    Honeycomb.start_span(name: "name retrieval") do |_span|
+      Faraday.new("http://localhost:8000")
+            .get("/name")
+            .body
+    end
   end
 end
 
 class MessageClient
   def self.get_message
-    Faraday.new("http://localhost:9000")
-           .get("/message")
-           .body
+    Honeycomb.start_span(name: "message retrieval") do |_span|
+      Faraday.new("http://localhost:9000")
+            .get("/message")
+            .body
+    end
   end
 end
 


### PR DESCRIPTION
This way all the differently-shaped spans generated by each languages's auto-instrumention will appear under something consistent. It's almost like naming your business logic brings meaning to the data generated by the robots.

* "✨  name retrieval ✨ " and "✨ greeting retrieval ✨" in the frontends
    - [ ] Go
    - [ ] Python
    - [ ] Ruby
* "✨  message generate ✨ " in the message-services
    - [ ] Go
    - [ ] Python
* "✨  name lookup ✨ " and "✨  year retrieval ✨ " in the name-services
    - [ ] Go
    - [ ] Python
    - [ ] Ruby
* "✨  year lookup ✨ " in the year-services
    - [ ] Go
    - [ ] Python
    - [ ] Java?