### PR TITLE
Clean up Java year service and better support use of the agent

### DIFF
--- a/java/year-service/build.gradle
+++ b/java/year-service/build.gradle
@@ -24,3 +24,9 @@ dependencies {
 test {
 	useJUnitPlatform()
 }
+
+task setEnvVars(type:Exec) { 
+	// expects AGENT_PATH to point to OpenTelemetry Java agent .jar file
+	// works for vanilla OpenTelemetry agent or Honeycomb OpenTelemetry agent distro
+	environment 'JAVA_TOOL_OPTIONS', '-javaagent:${AGENT_PATH}'
+	}

--- a/java/year-service/build.gradle
+++ b/java/year-service/build.gradle
@@ -4,14 +4,8 @@ plugins {
 	id 'java'
 }
 
-group = 'io.honeycomb.examples'
-version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-
 repositories {
 	mavenCentral()
-	// path to local .jar file
-	flatDir {	dirs System.getenv("BEESTRO_PATH") }
 }
 
 dependencies {
@@ -25,8 +19,6 @@ dependencies {
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
-
-	implementation 'io.honeycomb:honeycomb-opentelemetry-java:1.0-SNAPSHOT'
 }
 
 test {

--- a/java/year-service/src/main/java/io/honeycomb/examples/javaotlp/YearApplication.java
+++ b/java/year-service/src/main/java/io/honeycomb/examples/javaotlp/YearApplication.java
@@ -8,21 +8,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 
-import io.honeycomb.opentelemetry.HoneycombSdk;
-import io.honeycomb.opentelemetry.sdk.trace.samplers.DeterministicTraceSampler;
-
 @SpringBootApplication
 public class YearApplication {
-
-	@Bean // auto-injects dependencies into your controllers
-	public HoneycombSdk getHoneycomb() {
-		return HoneycombSdk.builder()
-    .setApiKey(System.getenv("HONEYCOMB_WRITE_KEY"))
-    .setDataset(System.getenv("HONEYCOMB_DATASET"))
-    .setEndpoint("https://api.honeycomb.io")
-    .setSampler(new DeterministicTraceSampler(5)) // optional - defaults  to "always sample"
-    .build();
-	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(YearApplication.class, args);


### PR DESCRIPTION
Works with both the vanilla OpenTelemetry agent and the Honeycomb OpenTelemetry agent distro.