### PR TITLE
more redis usage; run dotnet apps together via tilt and docker

### DIFF
--- a/dotnet/Tiltfile
+++ b/dotnet/Tiltfile
@@ -1,0 +1,6 @@
+docker_compose("./docker-compose.yml")
+
+local_resource(
+  'load messages into redis',
+  cmd='docker compose exec redis redis-cli -n 0 SADD messages "how are you?" "how are you doing?" "what\'s good?" "what\'s up?" "how do you do?" "sup?" "good day to you" "how are things?" "howzit?" "woohoo"',
+  resource_deps=['redis'])

--- a/dotnet/docker-compose.yml
+++ b/dotnet/docker-compose.yml
@@ -54,14 +54,3 @@ services:
     ports:
       - "127.0.0.1:6379:6379"
 
-  collector:
-    image: otel/opentelemetry-collector-dev:latest
-    command: ["--config=/etc/otel-collector-config.yaml"]
-    environment:
-      - HONEYCOMB_API_KEY
-      - HONEYCOMB_DATASET
-    volumes:
-      - ../otel-collector-config.yaml:/etc/otel-collector-config.yaml
-    ports:
-      - "127.0.0.1:55680:55680"
-      - "127.0.0.1:55681:55681"

--- a/dotnet/docker-compose.yml
+++ b/dotnet/docker-compose.yml
@@ -1,0 +1,67 @@
+version: "2.4"
+
+x-common-env: &common-env
+  HONEYCOMB_API_KEY:
+  HONEYCOMB_DATASET:
+  OTEL_EXPORTER_OTLP_ENDPOINT:
+  OTEL_RESOURCE_ATTRIBUTES: app.running-in=docker
+  Honeycomb__ApiKey: ${HONEYCOMB_API_KEY}
+  Honeycomb__Dataset: ${HONEYCOMB_DATASET}
+  Honeycomb__Endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+  Otlp__ApiKey: ${HONEYCOMB_API_KEY}
+  Otlp__Dataset: ${HONEYCOMB_DATASET}
+  Otlp__Endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+  MESSAGE_ENDPOINT: message:9000
+  NAME_ENDPOINT: name:8000
+  YEAR_ENDPOINT: year:6001
+  REDIS_URL: redis
+
+services:
+  frontend:
+    build: ./frontend
+    image: hnyexample/frontend-dotnet
+    environment:
+      <<: *common-env
+    ports:
+      - 7000:7000
+
+  message:
+    build: ./message-service
+    image: hnyexample/message-dotnet
+    environment:
+      <<: *common-env
+    ports:
+      - 9000:9000
+
+  name:
+    build: ./name-service
+    image: hnyexample/name-dotnet
+    environment:
+      <<: *common-env
+    ports:
+      - 8000:8000
+
+  year:
+    build: ./year-service
+    image: hnyexample/year-dotnet
+    environment:
+      <<: *common-env
+    ports:
+      - 6001:6001
+
+  redis:
+    image: redis:latest
+    ports:
+      - "127.0.0.1:6379:6379"
+
+  collector:
+    image: otel/opentelemetry-collector-dev:latest
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    environment:
+      - HONEYCOMB_API_KEY
+      - HONEYCOMB_DATASET
+    volumes:
+      - ../otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "127.0.0.1:55680:55680"
+      - "127.0.0.1:55681:55681"

--- a/dotnet/frontend/Controllers/GreetingController.cs
+++ b/dotnet/frontend/Controllers/GreetingController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -20,6 +21,28 @@ namespace frontend.Controllers
             _tracer = tracer;
         }
 
+        private static string GetNameEndpoint()
+        {
+            var nameEndpoint = Environment.GetEnvironmentVariable("NAME_ENDPOINT");
+            if (nameEndpoint == null)
+            {
+                return "http://localhost:8000/name";
+            } else {
+                return "http://" + nameEndpoint + "/name";
+            }
+        }
+
+        private static string GetMessageEndpoint()
+        {
+            var messageEndpoint = Environment.GetEnvironmentVariable("MESSAGE_ENDPOINT");
+            if (messageEndpoint == null)
+            {
+                return "http://localhost:9000/message";
+            } else {
+                return "http://" + messageEndpoint + "/message";
+            }
+        }
+
         [HttpGet]
         public async Task<string> GetAsync()
         {
@@ -38,7 +61,7 @@ namespace frontend.Controllers
 
         private static async Task<string> GetNameAsync(HttpClient client)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost:8000/name");
+            var request = new HttpRequestMessage(HttpMethod.Get, GetNameEndpoint());
             var response = await client.SendAsync(request);
             if (!response.IsSuccessStatusCode) return "OH NO!";
             return await response.Content.ReadAsStringAsync();
@@ -46,7 +69,7 @@ namespace frontend.Controllers
 
         private static async Task<string> GetMessage(HttpClient client)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost:9000/message");
+            var request = new HttpRequestMessage(HttpMethod.Get, GetMessageEndpoint());
             var response = await client.SendAsync(request);
             if (!response.IsSuccessStatusCode) return "OH NO!";
             return await response.Content.ReadAsStringAsync();

--- a/dotnet/frontend/Dockerfile
+++ b/dotnet/frontend/Dockerfile
@@ -19,6 +19,6 @@ WORKDIR /app
 COPY --from=build /app ./
 
 ENV ASPNETCORE_URLS=http://+:7000
-ENV ASPNETCORE_ENVIRONMENT=”development”
+ENV ASPNETCORE_ENVIRONMENT="development"
 EXPOSE 7000
 ENTRYPOINT ["dotnet", "frontend.dll"]

--- a/dotnet/frontend/Dockerfile
+++ b/dotnet/frontend/Dockerfile
@@ -1,0 +1,24 @@
+# https://hub.docker.com/_/microsoft-dotnet
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+WORKDIR /source
+
+# copy csproj and restore as distinct layers
+COPY *.cs .
+COPY *.csproj .
+COPY *.json .
+COPY ./Properties ./Properties
+COPY ./Controllers ./Controllers
+RUN dotnet restore
+
+# copy everything else and build app
+RUN dotnet publish -c release -o /app --no-restore
+
+# final stage/image
+FROM mcr.microsoft.com/dotnet/aspnet:5.0
+WORKDIR /app
+COPY --from=build /app ./
+
+ENV ASPNETCORE_URLS=http://+:7000
+ENV ASPNETCORE_ENVIRONMENT=”development”
+EXPOSE 7000
+ENTRYPOINT ["dotnet", "frontend.dll"]

--- a/dotnet/frontend/frontend.csproj
+++ b/dotnet/frontend/frontend.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Honeycomb.OpenTelemetry" Version="0.10.0-alpha" />
+    <PackageReference Include="Honeycomb.OpenTelemetry" Version="0.11.0-alpha" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
   </ItemGroup>

--- a/dotnet/message-service/Dockerfile
+++ b/dotnet/message-service/Dockerfile
@@ -1,0 +1,24 @@
+# https://hub.docker.com/_/microsoft-dotnet
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+WORKDIR /source
+
+# copy csproj and restore as distinct layers
+COPY *.cs .
+COPY *.csproj .
+COPY *.json .
+COPY ./Properties ./Properties
+COPY ./Controllers ./Controllers
+RUN dotnet restore
+
+# copy everything else and build app
+RUN dotnet publish -c release -o /app --no-restore
+
+# final stage/image
+FROM mcr.microsoft.com/dotnet/aspnet:5.0
+WORKDIR /app
+COPY --from=build /app ./
+
+ENV ASPNETCORE_URLS=http://+:9000
+ENV ASPNETCORE_ENVIRONMENT=”development”
+EXPOSE 9000
+ENTRYPOINT ["dotnet", "message-service.dll"]

--- a/dotnet/message-service/Dockerfile
+++ b/dotnet/message-service/Dockerfile
@@ -19,6 +19,6 @@ WORKDIR /app
 COPY --from=build /app ./
 
 ENV ASPNETCORE_URLS=http://+:9000
-ENV ASPNETCORE_ENVIRONMENT=”development”
+ENV ASPNETCORE_ENVIRONMENT="development"
 EXPOSE 9000
 ENTRYPOINT ["dotnet", "message-service.dll"]

--- a/dotnet/message-service/Startup.cs
+++ b/dotnet/message-service/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 using StackExchange.Redis;
+using System;
 
 namespace message_service
 {
@@ -27,10 +28,15 @@ namespace message_service
                 c.SwaggerDoc("v1", new OpenApiInfo {Title = "message_service", Version = "v1"});
             });
 
-            services.UseHoneycomb(Configuration);
-
-            var multiplexer = ConnectionMultiplexer.Connect("localhost");
+            var redisConfig = Environment.GetEnvironmentVariable("REDIS_URL");
+            if (redisConfig == null)
+            {
+                redisConfig = "localhost";
+            }
+            var multiplexer = ConnectionMultiplexer.Connect(redisConfig);
             services.AddSingleton<IConnectionMultiplexer>(multiplexer);
+
+            services.UseHoneycomb(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/dotnet/message-service/Startup.cs
+++ b/dotnet/message-service/Startup.cs
@@ -28,6 +28,8 @@ namespace message_service
                 c.SwaggerDoc("v1", new OpenApiInfo {Title = "message_service", Version = "v1"});
             });
 
+            services.UseHoneycomb(Configuration);
+
             var redisConfig = Environment.GetEnvironmentVariable("REDIS_URL");
             if (redisConfig == null)
             {
@@ -35,8 +37,6 @@ namespace message_service
             }
             var multiplexer = ConnectionMultiplexer.Connect(redisConfig);
             services.AddSingleton<IConnectionMultiplexer>(multiplexer);
-
-            services.UseHoneycomb(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/dotnet/message-service/Startup.cs
+++ b/dotnet/message-service/Startup.cs
@@ -30,12 +30,14 @@ namespace message_service
 
             services.UseHoneycomb(Configuration);
 
-            var redisConfig = Environment.GetEnvironmentVariable("REDIS_URL");
-            if (redisConfig == null)
+            var redisConfigString = Environment.GetEnvironmentVariable("REDIS_URL");
+            if (redisConfigString == null)
             {
-                redisConfig = "localhost";
+                redisConfigString = "localhost";
             }
-            var multiplexer = ConnectionMultiplexer.Connect(redisConfig);
+            var redisOptions = ConfigurationOptions.Parse(redisConfigString);
+            redisOptions.AbortOnConnectFail = false; // allow for reconnects if redis is not available
+            var multiplexer = ConnectionMultiplexer.Connect(redisOptions);
             services.AddSingleton<IConnectionMultiplexer>(multiplexer);
         }
 

--- a/dotnet/message-service/message-service.csproj
+++ b/dotnet/message-service/message-service.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Honeycomb.OpenTelemetry" Version="0.10.0-alpha" />
+    <PackageReference Include="Honeycomb.OpenTelemetry" Version="0.11.0-alpha" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.6" />
     <PackageReference Include="StackExchange.Redis" Version="2.2.62" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />

--- a/dotnet/name-service/Controllers/NameController.cs
+++ b/dotnet/name-service/Controllers/NameController.cs
@@ -18,6 +18,17 @@ namespace name_service.Controllers
             _clientFactory = clientFactory;
         }
 
+        private static string GetYearEndpoint()
+        {
+            var yearEndpoint = Environment.GetEnvironmentVariable("YEAR_ENDPOINT");
+            if (yearEndpoint == null)
+            {
+                return "http://localhost:6001/year";
+            } else {
+                return "http://" + yearEndpoint + "/year";
+            }
+        }
+
         private static readonly Dictionary<int, string[]> NamesByYear = new()
         {
             { 2015, new[] { "sophia", "jackson", "emma", "aiden", "olivia", "liam", "ava", "lucas", "mia", "noah" } },
@@ -36,7 +47,7 @@ namespace name_service.Controllers
             current?.AddTag("apple", 1);
             current?.AddBaggage("avocado", "12");
 
-            var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost:6001/year");
+            var request = new HttpRequestMessage(HttpMethod.Get, GetYearEndpoint());
             var client = _clientFactory.CreateClient();
             var response = await client.SendAsync(request);
             if (!response.IsSuccessStatusCode) return "OH NO!";

--- a/dotnet/name-service/Dockerfile
+++ b/dotnet/name-service/Dockerfile
@@ -1,0 +1,24 @@
+# https://hub.docker.com/_/microsoft-dotnet
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+WORKDIR /source
+
+# copy csproj and restore as distinct layers
+COPY *.cs .
+COPY *.csproj .
+COPY *.json .
+COPY ./Properties ./Properties
+COPY ./Controllers ./Controllers
+RUN dotnet restore
+
+# copy everything else and build app
+RUN dotnet publish -c release -o /app --no-restore
+
+# final stage/image
+FROM mcr.microsoft.com/dotnet/aspnet:5.0
+WORKDIR /app
+COPY --from=build /app ./
+
+ENV ASPNETCORE_URLS=http://+:8000
+ENV ASPNETCORE_ENVIRONMENT=”development”
+EXPOSE 8000
+ENTRYPOINT ["dotnet", "name-service.dll"]

--- a/dotnet/name-service/Dockerfile
+++ b/dotnet/name-service/Dockerfile
@@ -19,6 +19,6 @@ WORKDIR /app
 COPY --from=build /app ./
 
 ENV ASPNETCORE_URLS=http://+:8000
-ENV ASPNETCORE_ENVIRONMENT=”development”
+ENV ASPNETCORE_ENVIRONMENT="development"
 EXPOSE 8000
 ENTRYPOINT ["dotnet", "name-service.dll"]

--- a/dotnet/name-service/Startup.cs
+++ b/dotnet/name-service/Startup.cs
@@ -36,7 +36,9 @@ namespace name_service
 
             services.AddOpenTelemetryTracing((builder => builder
                 .SetResourceBuilder(ResourceBuilder.CreateDefault()
-                    .AddService(this.Configuration.GetValue<string>("Otlp:ServiceName")))
+                    .AddService(this.Configuration.GetValue<string>("Otlp:ServiceName"))
+                    .AddEnvironmentVariableDetector()
+                )
                 .AddSource(ActivitySourceName)
                 .AddAspNetCoreInstrumentation(options => options.Enrich = (activity, eventName, rawObject) =>
                 {

--- a/dotnet/year-service/Dockerfile
+++ b/dotnet/year-service/Dockerfile
@@ -19,6 +19,6 @@ WORKDIR /app
 COPY --from=build /app ./
 
 ENV ASPNETCORE_URLS=http://+:6001
-ENV ASPNETCORE_ENVIRONMENT=”development”
+ENV ASPNETCORE_ENVIRONMENT="development"
 EXPOSE 6001
 ENTRYPOINT ["dotnet", "year-service.dll"]

--- a/dotnet/year-service/Dockerfile
+++ b/dotnet/year-service/Dockerfile
@@ -1,0 +1,24 @@
+# https://hub.docker.com/_/microsoft-dotnet
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+WORKDIR /source
+
+# copy csproj and restore as distinct layers
+COPY *.cs .
+COPY *.csproj .
+COPY *.json .
+COPY ./Properties ./Properties
+COPY ./Controllers ./Controllers
+RUN dotnet restore
+
+# copy everything else and build app
+RUN dotnet publish -c release -o /app --no-restore
+
+# final stage/image
+FROM mcr.microsoft.com/dotnet/aspnet:5.0
+WORKDIR /app
+COPY --from=build /app ./
+
+ENV ASPNETCORE_URLS=http://+:6001
+ENV ASPNETCORE_ENVIRONMENT=”development”
+EXPOSE 6001
+ENTRYPOINT ["dotnet", "year-service.dll"]

--- a/dotnet/year-service/Startup.cs
+++ b/dotnet/year-service/Startup.cs
@@ -34,7 +34,9 @@ namespace year_service
 
             services.AddOpenTelemetryTracing(builder => builder
                 .SetResourceBuilder(ResourceBuilder.CreateDefault()
-                    .AddService(this.Configuration.GetValue<string>("Otlp:ServiceName")))
+                    .AddService(this.Configuration.GetValue<string>("Otlp:ServiceName"))
+                    .AddEnvironmentVariableDetector()
+                )
                 .AddSource(ActivitySourceName)
                 .AddAspNetCoreInstrumentation()
                 .AddHttpClientInstrumentation()


### PR DESCRIPTION
With this PR, you can change directory to `dotnet/`, run `tilt up` and have a wholly .NET experience that hangs together. Updating the root Tilt could happen in this PR or in a subsequent one, but until that Tilt is taught the same "load messages into Redis" the Message service will always return "generic hello".

Updates the message-dotnet microservice to retrieve a message from Redis to demonstrate redis autoinstrumentation.

Updates the stock OTel services (name and year) to include resource attributes set via environment variable.