### PR TITLE
Adds w3c interop for mixed beeline and OTEL

### DIFF
--- a/node/frontend/main.js
+++ b/node/frontend/main.js
@@ -1,11 +1,15 @@
 'use strict';
-const beeline = require('honeycomb-beeline')({
+const beeline = require('honeycomb-beeline');
+
+beeline({
   // Get this via https://ui.honeycomb.io/account after signing up for Honeycomb
   writeKey: `${process.env.HONEYCOMB_API_KEY}`,
   // The name of your app is a good choice to start with
   dataset: `${process.env.HONEYCOMB_DATASET}`,
   serviceName: `${process.env.SERVICE_NAME}` || 'node-frontend-service',
   apiHost: `${process.env.HONEYCOMB_API}` || 'https://api.honeycomb.io',
+  httpTraceParserHook: beeline.w3c.httpTraceParserHook,
+  httpTracePropagationHook: beeline.w3c.httpTracePropagationHook
 });
 
 const express = require('express');

--- a/node/message-service/main.js
+++ b/node/message-service/main.js
@@ -1,11 +1,15 @@
 'use strict';
-const beeline = require('honeycomb-beeline')({
+const beeline = require('honeycomb-beeline');
+
+beeline({
   // Get this via https://ui.honeycomb.io/account after signing up for Honeycomb
   writeKey: `${process.env.HONEYCOMB_API_KEY}`,
   // The name of your app is a good choice to start with
   dataset: `${process.env.HONEYCOMB_DATASET}`,
   serviceName: `${process.env.SERVICE_NAME}` || 'node-message-service',
   apiHost: `${process.env.HONEYCOMB_API}` || 'https://api.honeycomb.io',
+  httpTraceParserHook: beeline.w3c.httpTraceParserHook,
+  httpTracePropagationHook: beeline.w3c.httpTracePropagationHook
 });
 
 const express = require('express');

--- a/node/name-service/main.js
+++ b/node/name-service/main.js
@@ -1,11 +1,15 @@
 'use strict';
-const beeline = require('honeycomb-beeline')({
+const beeline = require('honeycomb-beeline');
+
+beeline({
   // Get this via https://ui.honeycomb.io/account after signing up for Honeycomb
   writeKey: `${process.env.HONEYCOMB_API_KEY}`,
   // The name of your app is a good choice to start with
   dataset: `${process.env.HONEYCOMB_DATASET}`,
   serviceName: `${process.env.SERVICE_NAME}` || 'node-name-service',
   apiHost: `${process.env.HONEYCOMB_API}` || 'https://api.honeycomb.io',
+  httpTraceParserHook: beeline.w3c.httpTraceParserHook,
+  httpTracePropagationHook: beeline.w3c.httpTracePropagationHook
 });
 
 const express = require('express');


### PR DESCRIPTION
Follow-up found in #51 ...

Adds`httpTraceParserHook` and `httpTracePropagationHook` to services using beelines to [support trace across services](https://docs.honeycomb.io/getting-data-in/javascript/beeline-nodejs/#interoperability-with-opentelemetry) instrumented with Beeline and OTEL.