### PR TITLE
Update Java to use honey sdk for otel api

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -99,7 +99,10 @@ def launch_java_svc(name, dirname="", flags="", auto_init=True):
     flags: (optional) any additional flags to add to the command line
     '''
 
-    env = {'SERVICE_NAME': name}
+    env = {
+        'SERVICE_NAME': name,
+        'OTEL_SERVICE_NAME': name
+    }
     cmd = "cd {} && gradle bootRun".format(
         dirname if dirname else name,
         flags if flags else ""

--- a/java/frontend/Dockerfile
+++ b/java/frontend/Dockerfile
@@ -1,18 +1,18 @@
 FROM gradle:7.0.1-jdk11 AS build
 WORKDIR /home/gradle/
 RUN mkdir ./libs
-ENV HONEY_OTEL_VER=0.1.1
-ENV HONEY_JAVA_AGENT=honeycomb-opentelemetry-javaagent-${HONEY_OTEL_VER}-all.jar
-ADD https://github.com/honeycombio/honeycomb-opentelemetry-java/releases/download/v${HONEY_OTEL_VER}/${HONEY_JAVA_AGENT} ./libs
+ENV OTEL_AGENT_VER=1.5.3
+ENV JAVA_AGENT=opentelemetry-javaagent-all.jar
+ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_AGENT_VER}/${JAVA_AGENT} ./libs
 COPY --chown=gradle:gradle *.gradle ./
 COPY --chown=gradle:gradle ./src ./src
 RUN gradle bootJar --no-daemon
 
 FROM openjdk:13-jdk-alpine
 VOLUME /tmp
-ENV HONEY_OTEL_VER=0.1.1
-ENV HONEY_JAVA_AGENT=honeycomb-opentelemetry-javaagent-${HONEY_OTEL_VER}-all.jar
-ENV JAVA_TOOL_OPTIONS=-javaagent:${HONEY_JAVA_AGENT}
-COPY --from=build /home/gradle/libs/${HONEY_JAVA_AGENT} ./${HONEY_JAVA_AGENT}
+ENV OTEL_AGENT_VER=1.5.3
+ENV JAVA_AGENT=opentelemetry-javaagent-all.jar
+ENV JAVA_TOOL_OPTIONS=-javaagent:${JAVA_AGENT}
+COPY --from=build /home/gradle/libs/${JAVA_AGENT} ./${JAVA_AGENT}
 COPY --from=build /home/gradle/build/libs/*.jar app.jar
 CMD ["java", "-jar", "app.jar"]

--- a/java/frontend/build.gradle
+++ b/java/frontend/build.gradle
@@ -9,8 +9,8 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 ext {
-    otelVersion = '1.0.1'
-		beestroVersion = '0.3.0'
+    otelVersion = '1.5.0'
+    otelAgentVersion = '1.5.3'
 }
 
 configurations {
@@ -20,14 +20,13 @@ configurations {
 repositories {
     mavenCentral()
     mavenLocal()
-    flatDir { dirs "libs" }
 }
 
 dependencies {
     implementation("io.opentelemetry:opentelemetry-api:${otelVersion}")
     implementation("io.opentelemetry:opentelemetry-extension-annotations:${otelVersion}")
 
-    agent "io.honeycomb:honeycomb-opentelemetry-javaagent:${beestroVersion}:all"
+    agent "io.opentelemetry.javaagent:opentelemetry-javaagent:${otelAgentVersion}:all"
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
@@ -37,17 +36,17 @@ dependencies {
 
 task copyAgentJar(type: Copy) {
     from configurations.agent {
-        include '**/honeycomb-opentelemetry-javaagent*.jar'
+        include '**/opentelemetry-javaagent*.jar'
     }
     into "agent"
-    rename { fileName -> "honey-javaagent.jar" }
+    rename { fileName -> "otel-javaagent.jar" }
 }
 
 compileJava.dependsOn copyAgentJar
 bootRun.dependsOn copyAgentJar
 
 bootRun.doFirst {
-    jvmArgs("-javaagent:agent/honey-javaagent.jar")
+    jvmArgs("-javaagent:agent/otel-javaagent.jar")
 }
 
 clean.doFirst {

--- a/java/frontend/src/main/java/io/honeycomb/examples/frontend_java/FrontendApplication.java
+++ b/java/frontend/src/main/java/io/honeycomb/examples/frontend_java/FrontendApplication.java
@@ -1,23 +1,23 @@
 package io.honeycomb.examples.frontend_java;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
-// import io.honeycomb.opentelemetry.HoneycombSdk;
-// import io.honeycomb.opentelemetry.sdk.trace.samplers.DeterministicTraceSampler;
 
 @SpringBootApplication
 public class FrontendApplication {
 
-	@Bean
-	public Tracer tracer() {
-			return GlobalOpenTelemetry.getTracer("frontend-internal");
-	}
+    @Bean
+    public Tracer tracer() {
+        return GlobalOpenTelemetry.getTracer("frontend-internal");
+    }
 
-	public static void main(String[] args) {
-		SpringApplication.run(FrontendApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(FrontendApplication.class, args);
+    }
 }

--- a/java/frontend/src/main/java/io/honeycomb/examples/frontend_java/FrontendApplication.java
+++ b/java/frontend/src/main/java/io/honeycomb/examples/frontend_java/FrontendApplication.java
@@ -6,9 +6,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.trace.Tracer;
-
 @SpringBootApplication
 public class FrontendApplication {
 

--- a/java/frontend/src/main/java/io/honeycomb/examples/frontend_java/GreetingController.java
+++ b/java/frontend/src/main/java/io/honeycomb/examples/frontend_java/GreetingController.java
@@ -35,19 +35,9 @@ public class GreetingController {
 
 		String message = messageService.getMessage();
 
-		Span render_span = tracer.spanBuilder("🎨 render message ✨").startSpan();
+		Span span = tracer.spanBuilder("🎨 render message ✨").startSpan();
 		String greeting = String.format("Hello, %s, %s", name, message);
-		render_span.end();
+		span.end();
 		return greeting;
-	}
-
-	private void addTraceField(String key, String value) {
-		Span.current().setAttribute(key, value);
-
-		Baggage.current()
-			.toBuilder()
-			.put(key, value)
-			.build()
-			.makeCurrent();
 	}
 }

--- a/java/frontend/src/main/java/io/honeycomb/examples/frontend_java/MessageService.java
+++ b/java/frontend/src/main/java/io/honeycomb/examples/frontend_java/MessageService.java
@@ -25,7 +25,7 @@ public class MessageService {
   }
 
   @WithSpan
-  public String getMessage() throws URISyntaxException, IOException, InterruptedException {
+  public String getMessage() throws URISyntaxException {
     URI message_uri = new URI(message_endpoint());
 
     HttpClient client = HttpClient.newHttpClient();
@@ -35,10 +35,10 @@ public class MessageService {
         .build();
     HttpResponse<String> response = null;
     try {
-      Span message_service_call_span = tracer.spanBuilder("✨ call /message ✨").startSpan();
-      message_service_call_span.makeCurrent();
+      Span messageServiceCallSpan = tracer.spanBuilder("✨ call /message ✨").startSpan();
+      messageServiceCallSpan.makeCurrent();
       response = client.send(request, HttpResponse.BodyHandlers.ofString());
-      message_service_call_span.end();
+      messageServiceCallSpan.end();
     } catch (IOException | InterruptedException e) {
         e.printStackTrace();
 

--- a/java/frontend/src/main/java/io/honeycomb/examples/frontend_java/NameService.java
+++ b/java/frontend/src/main/java/io/honeycomb/examples/frontend_java/NameService.java
@@ -24,7 +24,7 @@ public class NameService {
     return nameEndpointFromEnv + "/name";
   }
   @WithSpan
-  public String getName() throws URISyntaxException, IOException, InterruptedException {
+  public String getName() throws URISyntaxException {
     URI name_uri = new URI(name_endpoint());
 
     HttpClient client = HttpClient.newHttpClient();
@@ -34,10 +34,10 @@ public class NameService {
       .build();
     HttpResponse<String> response = null;
     try {
-      Span name_service_call_span = tracer.spanBuilder("✨ call /name ✨").startSpan();
-      name_service_call_span.makeCurrent();
+      Span nameServiceCallSpan = tracer.spanBuilder("✨ call /name ✨").startSpan();
+      nameServiceCallSpan.makeCurrent();
       response = client.send(request, HttpResponse.BodyHandlers.ofString());
-      name_service_call_span.end();
+      nameServiceCallSpan.end();
     } catch (IOException | InterruptedException e) {
       e.printStackTrace();
     }

--- a/java/message-service/build.gradle
+++ b/java/message-service/build.gradle
@@ -9,8 +9,7 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 ext {
-    otelVersion = '1.0.1'
-    beestroVersion = '0.3.0'
+    beestroVersion = '0.4.0'
 }
 
 configurations {
@@ -20,15 +19,12 @@ configurations {
 repositories {
     mavenCentral()
     mavenLocal()
-    flatDir { dirs "libs" }
 }
 
 dependencies {
-    implementation("io.opentelemetry:opentelemetry-api:${otelVersion}")
-    implementation("io.opentelemetry:opentelemetry-extension-annotations:${otelVersion}")
-
     agent "io.honeycomb:honeycomb-opentelemetry-javaagent:${beestroVersion}:all"
 
+    implementation("io.honeycomb:honeycomb-opentelemetry-sdk:${beestroVersion}")
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/java/message-service/src/main/java/io/honeycomb/examples/message/MessageService.java
+++ b/java/message-service/src/main/java/io/honeycomb/examples/message/MessageService.java
@@ -24,11 +24,11 @@ public class MessageService {
     }
 
     private String pickMessage() {
-        Span message_lookup_span = tracer.spanBuilder("📖 look up message ✨").startSpan();
-        message_lookup_span.makeCurrent();
+        Span messageLookupSpan = tracer.spanBuilder("📖 look up message ✨").startSpan();
+        messageLookupSpan.makeCurrent();
         int rnd = generator.nextInt(MESSAGES.length);
         String message = MESSAGES[rnd];
-        message_lookup_span.end();
+        messageLookupSpan.end();
         return message;
     }
 }

--- a/java/name-service/build.gradle
+++ b/java/name-service/build.gradle
@@ -9,8 +9,7 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 ext {
-    otelVersion = '1.0.1'
-    beestroVersion = '0.3.0'
+    beestroVersion = '0.4.0'
 }
 
 configurations {
@@ -20,16 +19,12 @@ configurations {
 repositories {
     mavenCentral()
     mavenLocal()
-    // path to local .jar file
-    flatDir { dirs "libs" }
 }
 
 dependencies {
-    implementation("io.opentelemetry:opentelemetry-api:${otelVersion}")
-    implementation("io.opentelemetry:opentelemetry-extension-annotations:${otelVersion}")
-
     agent "io.honeycomb:honeycomb-opentelemetry-javaagent:${beestroVersion}:all"
 
+    implementation("io.honeycomb:honeycomb-opentelemetry-sdk:${beestroVersion}")
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/java/name-service/src/main/java/io/honeycomb/examples/name/MessageService.java
+++ b/java/name-service/src/main/java/io/honeycomb/examples/name/MessageService.java
@@ -22,7 +22,7 @@ public class MessageService {
   private String message_endpoint = "http://localhost:9000/message";
 
   @WithSpan
-  public String getMessage() throws URISyntaxException, IOException, InterruptedException {
+  public String getMessage() throws URISyntaxException {
     URI message_uri = new URI(message_endpoint);
 
     HttpClient client = HttpClient.newHttpClient();
@@ -32,10 +32,10 @@ public class MessageService {
         .build();
     HttpResponse<String> response = null;
     try {
-      Span message_service_call_span = tracer.spanBuilder("✨ call /name ✨").startSpan();
-      message_service_call_span.makeCurrent();
+      Span messageServiceCallSpan = tracer.spanBuilder("✨ call /name ✨").startSpan();
+      messageServiceCallSpan.makeCurrent();
       response = client.send(request, HttpResponse.BodyHandlers.ofString());
-      message_service_call_span.end();
+      messageServiceCallSpan.end();
     } catch (IOException | InterruptedException e) {
         e.printStackTrace();
 

--- a/java/name-service/src/main/java/io/honeycomb/examples/name/NameController.java
+++ b/java/name-service/src/main/java/io/honeycomb/examples/name/NameController.java
@@ -19,8 +19,6 @@ public class NameController {
 
 	@RequestMapping("/name")
 	public String index() throws URISyntaxException, IOException, InterruptedException {
-		String name = nameService.getName();
-
-		return name;
+        return nameService.getName();
 	}
 }

--- a/java/name-service/src/main/java/io/honeycomb/examples/name/NameService.java
+++ b/java/name-service/src/main/java/io/honeycomb/examples/name/NameService.java
@@ -18,13 +18,13 @@ public class NameService {
   @Autowired
   private Tracer tracer;
 
-  private static final Map<Integer,String[]> namesByYear = new HashMap<Integer,String[]>(){{
-    this.put(2015, new String[] {"sophia", "jackson", "emma", "aiden", "olivia", "liam", "ava", "lucas", "mia", "noah"});
-    this.put(2016, new String[] {"sophia", "jackson", "emma", "aiden", "olivia", "lucas", "ava", "liam", "mia", "noah"});
-    this.put(2017, new String[] {"sophia", "jackson", "olivia", "liam", "emma", "noah", "ava", "aiden", "isabella", "lucas"});
-    this.put(2018, new String[] {"sophia", "jackson", "olivia", "liam", "emma", "noah", "ava", "aiden", "isabella", "caden"});
-    this.put(2019, new String[] {"sophia", "liam", "olivia", "jackson", "emma", "noah", "ava", "aiden", "aira", "grayson"});
-    this.put(2020, new String[] {"olivia", "noah", "emma", "liam", "ava", "elijah", "isabella", "oliver", "sophia", "lucas"});
+  private static final Map<Integer,String[]> namesByYear = new HashMap<>() {{
+      this.put(2015, new String[]{"sophia", "jackson", "emma", "aiden", "olivia", "liam", "ava", "lucas", "mia", "noah"});
+      this.put(2016, new String[]{"sophia", "jackson", "emma", "aiden", "olivia", "lucas", "ava", "liam", "mia", "noah"});
+      this.put(2017, new String[]{"sophia", "jackson", "olivia", "liam", "emma", "noah", "ava", "aiden", "isabella", "lucas"});
+      this.put(2018, new String[]{"sophia", "jackson", "olivia", "liam", "emma", "noah", "ava", "aiden", "isabella", "caden"});
+      this.put(2019, new String[]{"sophia", "liam", "olivia", "jackson", "emma", "noah", "ava", "aiden", "aira", "grayson"});
+      this.put(2020, new String[]{"olivia", "noah", "emma", "liam", "ava", "elijah", "isabella", "oliver", "sophia", "lucas"});
   }};
 
   private static final Random generator = new Random();
@@ -36,12 +36,12 @@ public class NameService {
   public String getName() throws NumberFormatException, URISyntaxException, IOException, InterruptedException {
     int year = Integer.parseInt(yearService.getYear());
 
-    Span name_lookup_span = tracer.spanBuilder("📖 look up name based on year ✨").startSpan();
-    name_lookup_span.makeCurrent();
-    String[] candidate_names = namesByYear.get(year);
-    int rnd = generator.nextInt(candidate_names.length);
-    String name = candidate_names[rnd];
-    name_lookup_span.end();
+    Span nameLookupSpan = tracer.spanBuilder("📖 look up name based on year ✨").startSpan();
+    nameLookupSpan.makeCurrent();
+    String[] candidateNames = namesByYear.get(year);
+    int rnd = generator.nextInt(candidateNames.length);
+    String name = candidateNames[rnd];
+    nameLookupSpan.end();
 
     return name;
   }

--- a/java/name-service/src/main/java/io/honeycomb/examples/name/YearService.java
+++ b/java/name-service/src/main/java/io/honeycomb/examples/name/YearService.java
@@ -17,35 +17,35 @@ import io.opentelemetry.extension.annotations.WithSpan;
 
 @Component
 public class YearService {
-  @Autowired
-	private Tracer tracer;
+    @Autowired
+    private Tracer tracer;
 
-  private String year_endpoint() {
-    String yearEndpointFromEnv = System.getenv().getOrDefault("YEAR_ENDPOINT", "http://localhost:6001");
-    return yearEndpointFromEnv + "/year";
-  }
-
-  @WithSpan
-  public String getYear() throws URISyntaxException, IOException, InterruptedException {
-    URI year_uri = new URI(year_endpoint());
-
-    HttpClient client = HttpClient.newHttpClient();
-    HttpRequest request = HttpRequest.newBuilder()
-      .uri(year_uri)
-      .header("accept", "application/json")
-      .build();
-    HttpResponse<String> response = null;
-    Span year_service_call_span = tracer.spanBuilder("✨ call /year ✨").startSpan();
-    year_service_call_span.makeCurrent();
-    try {
-      response = client.send(request, HttpResponse.BodyHandlers.ofString());
-    } catch (IOException | InterruptedException e) {
-      e.printStackTrace();
-    } finally {
-      year_service_call_span.end();
+    private String year_endpoint() {
+        String yearEndpointFromEnv = System.getenv().getOrDefault("YEAR_ENDPOINT", "http://localhost:6001");
+        return yearEndpointFromEnv + "/year";
     }
-    return response == null
-      ? ""
-      : response.body();
-  }
+
+    @WithSpan
+    public String getYear() throws URISyntaxException {
+        URI yearUri = new URI(year_endpoint());
+
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(yearUri)
+            .header("accept", "application/json")
+            .build();
+        HttpResponse<String> response = null;
+        Span yearServiceCallSpan = tracer.spanBuilder("✨ call /year ✨").startSpan();
+        yearServiceCallSpan.makeCurrent();
+        try {
+            response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        } finally {
+            yearServiceCallSpan.end();
+        }
+        return response == null
+            ? ""
+            : response.body();
+    }
 }

--- a/java/year-service/build.gradle
+++ b/java/year-service/build.gradle
@@ -9,18 +9,15 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 ext {
-    otelVersion = '1.0.1'
-    beestroVersion = '0.3.0'
+    beestroVersion = '0.4.0'
 }
 
 repositories {
     mavenCentral()
     mavenLocal()
-    flatDir { dirs "libs" }
 }
 
 dependencies {
-    implementation("io.opentelemetry:opentelemetry-api:${otelVersion}")
     implementation("io.honeycomb:honeycomb-opentelemetry-sdk:${beestroVersion}")
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {

--- a/java/year-service/gradlew
+++ b/java/year-service/gradlew
@@ -72,7 +72,7 @@ case "`uname`" in
   Darwin* )
     darwin=true
     ;;
-  MINGW* )
+  MSYS* | MINGW* )
     msys=true
     ;;
   NONSTOP* )


### PR DESCRIPTION
honeycomb sdk provides the otel api (that matches the underlying sdk version), use the honey sdk instead of explicitly depending on otel api (this is what public docs already recommend)