### PR TITLE
dotnet: use trace api everywhere

### DIFF
--- a/dotnet/name-service/Startup.cs
+++ b/dotnet/name-service/Startup.cs
@@ -7,14 +7,12 @@ using Microsoft.OpenApi.Models;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using System;
-using System.Diagnostics;
 
 namespace name_service
 {
     public class Startup
     {
-        private const string _activitySourceName = "honeycomb.examples.name-service-dotnet";
-        public static readonly ActivitySource ActivitySource = new(_activitySourceName);
+        public const string TelemetrySourceName = "honeycomb.examples.name-service-dotnet";
 
         public Startup(IConfiguration configuration)
         {
@@ -39,7 +37,7 @@ namespace name_service
                     .AddService(this.Configuration.GetValue<string>("Otlp:ServiceName"))
                     .AddEnvironmentVariableDetector()
                 )
-                .AddSource(_activitySourceName)
+                .AddSource(TelemetrySourceName)
                 .AddAspNetCoreInstrumentation()
                 .AddHttpClientInstrumentation()
                 .AddOtlpExporter(options =>

--- a/dotnet/year-service/Program.cs
+++ b/dotnet/year-service/Program.cs
@@ -3,14 +3,14 @@ using OpenTelemetry.Trace;
 
 var builder = WebApplication.CreateBuilder(args);
 
-const string activitySourceName = "honeycomb.examples.year-service-dotnet";
+const string telemetrySourceName = "honeycomb.examples.year-service-dotnet";
 
 builder.Services.AddOpenTelemetryTracing(providerBuilder => providerBuilder
     .SetResourceBuilder(ResourceBuilder.CreateDefault()
         .AddService(builder.Configuration.GetValue<string>("Otlp:ServiceName"))
         .AddEnvironmentVariableDetector()
     )
-    .AddSource(activitySourceName)
+    .AddSource(telemetrySourceName)
     .AddAspNetCoreInstrumentation()
     .AddHttpClientInstrumentation()
     .AddOtlpExporter(options =>
@@ -21,7 +21,7 @@ builder.Services.AddOpenTelemetryTracing(providerBuilder => providerBuilder
         options.Headers = $"x-honeycomb-team={apiKey},x-honeycomb-dataset={dataset}";
     }));
 
-Tracer tracer = TracerProvider.Default.GetTracer(activitySourceName);
+Tracer tracer = TracerProvider.Default.GetTracer(telemetrySourceName);
 var app = builder.Build();
 int[] years =
 {


### PR DESCRIPTION
Switching the remaining services to use Trace API instead of Activity for consistency.