### PR TITLE
add docker compose for golang

### DIFF
--- a/golang/docker-compose.yml
+++ b/golang/docker-compose.yml
@@ -1,0 +1,50 @@
+version: "2.4"
+
+x-common-env: &common-env
+  HONEYCOMB_API_KEY:
+  HONEYCOMB_DATASET:
+  OTEL_EXPORTER_OTLP_ENDPOINT:
+  OTEL_RESOURCE_ATTRIBUTES: app.running-in=docker
+  MESSAGE_ENDPOINT: http://message:9000
+  NAME_ENDPOINT: http://name:8000
+  YEAR_ENDPOINT: http://year:6001
+  REDIS_URL: redis
+
+services:
+  frontend:
+    build: ./frontend
+    image: hnyexample/frontend-golang
+    environment:
+      <<: *common-env
+    ports:
+      - 7000:7000
+
+  message:
+    build: ./message-service
+    image: hnyexample/message-golang
+    environment:
+      <<: *common-env
+    ports:
+      - 9000:9000
+
+  name:
+    build: ./name-service
+    image: hnyexample/name-golang
+    environment:
+      <<: *common-env
+    ports:
+      - 8000:8000
+
+  year:
+    build: ./year-service
+    image: hnyexample/year-golang
+    environment:
+      <<: *common-env
+    ports:
+      - 6001:6001
+
+  redis:
+    image: redis:latest
+    ports:
+      - "127.0.0.1:6379:6379"
+


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- go services run fine in Tilt; this allows it to run without Tilt using docker

## Short description of the changes

- add docker-compose file
- endpoints include `http://`. alternative may be to remove the `http://` in tilt env and docker-compose, and add into the services themselves.

