### PR TITLE
[ruby] Add docker-compose and adjust dockerfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -452,3 +452,9 @@ $RECYCLE.BIN/
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+.direnv/
+*.direnv/
+*.direnv/cache/
+.envrc
+.env

--- a/ruby/docker-compose.yml
+++ b/ruby/docker-compose.yml
@@ -1,0 +1,51 @@
+version: "2.4"
+
+x-common-env: &common-env
+  HONEYCOMB_API_KEY:
+  HONEYCOMB_DATASET:
+  HONEYCOMB_API:
+  OTEL_EXPORTER_OTLP_ENDPOINT:
+  OTEL_EXPORTER_OTLP_HEADERS:
+  OTEL_RESOURCE_ATTRIBUTES: app.running-in=docker
+  MESSAGE_ENDPOINT: http://message:9000
+  NAME_ENDPOINT: http://name:8000
+  YEAR_ENDPOINT: http://year:6001
+  REDIS_URL: redis
+
+services:
+  frontend:
+    build: ./frontend
+    image: hnyexample/frontend-ruby
+    environment:
+      <<: *common-env
+    ports:
+      - 7000:7000
+
+  message:
+    build: ./message-service
+    image: hnyexample/message-ruby
+    environment:
+      <<: *common-env
+    ports:
+      - 9000:9000
+
+  name:
+    build: ./name-service
+    image: hnyexample/name-ruby
+    environment:
+      <<: *common-env
+    ports:
+      - 8000:8000
+
+  year:
+    build: ./year-service
+    image: hnyexample/year-ruby
+    environment:
+      <<: *common-env
+    ports:
+      - 6001:6001
+
+  redis:
+    image: redis:latest
+    ports:
+      - "127.0.0.1:6379:6379"

--- a/ruby/frontend/Gemfile
+++ b/ruby/frontend/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rails'
 gem 'puma'
-gem 'opentelemetry-sdk', '~> 1.0.0.rc2'
+gem 'opentelemetry-sdk'
 gem 'opentelemetry-exporter-otlp'
 gem 'opentelemetry-instrumentation-all'
 gem 'faraday'

--- a/ruby/message-service/Dockerfile
+++ b/ruby/message-service/Dockerfile
@@ -6,4 +6,4 @@ RUN bundle install
 COPY message.ru /myapp
 
 EXPOSE 9000
-CMD [ "rackup", "message.ru", "--server", "puma", "--host", "0.0.0.0"]
+CMD [ "bundle", "exec", "rackup", "message.ru", "--server", "puma", "--host", "0.0.0.0"]

--- a/ruby/name-service/Dockerfile
+++ b/ruby/name-service/Dockerfile
@@ -6,4 +6,4 @@ RUN bundle install
 COPY name.rb /myapp
 
 EXPOSE 8000
-CMD [ "ruby", "name.rb"]
+CMD [ "bundle", "exec", "ruby", "name.rb"]

--- a/ruby/year-service/Dockerfile
+++ b/ruby/year-service/Dockerfile
@@ -7,4 +7,4 @@ RUN bundle install
 COPY config.ru /app
 
 EXPOSE 6001
-CMD ["rackup", "--host", "0.0.0.0", "--port", "6001"]
+CMD ["bundle", "exec", "rackup", "--host", "0.0.0.0", "--port", "6001"]


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- this makes for a quick ruby spinup in docker with docker-compose, and also makes it easier to point to a specific branch for testing when using docker

## Short description of the changes

- ignore `direnv` and `env`-like files
- add `bundle exec` to Dockerfiles
- use latest otel sdk
