### PR TITLE
Merge default resource with custom attrs

### DIFF
--- a/golang/frontend/main.go
+++ b/golang/frontend/main.go
@@ -64,11 +64,12 @@ func newExporter(ctx context.Context) (*otlptrace.Exporter, error) {
 }
 
 func newTraceProvider(exp *otlptrace.Exporter) *sdktrace.TracerProvider {
-	r :=
+	r, _ := resource.Merge(
+		resource.Default(),
 		resource.NewWithAttributes(
 			semconv.SchemaURL,
 			semconv.ServiceNameKey.String("frontend-go"),
-		)
+		))
 
 	return sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exp),
@@ -108,6 +109,7 @@ func main() {
 
 	wrappedHandler := otelhttp.NewHandler(mux, "frontend")
 
+	log.Println("Listening on http://localhost:7000/greeting")
 	log.Fatal(http.ListenAndServe(":7000", wrappedHandler))
 }
 

--- a/golang/message-service/main.go
+++ b/golang/message-service/main.go
@@ -59,6 +59,7 @@ func main() {
 		_, _ = fmt.Fprintf(w, messages[rand.Intn(len(messages))])
 	})
 
+	log.Println("Listening on http://localhost:9000/message")
 	log.Fatal(
 		http.ListenAndServe(
 			":9000",

--- a/golang/name-service/main.go
+++ b/golang/name-service/main.go
@@ -66,11 +66,12 @@ func newExporter(ctx context.Context) (*otlptrace.Exporter, error) {
 }
 
 func newTraceProvider(exp *otlptrace.Exporter) *sdktrace.TracerProvider {
-	r :=
+	r, _ := resource.Merge(
+		resource.Default(),
 		resource.NewWithAttributes(
 			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("name-go"), // lol no generics
-		)
+			semconv.ServiceNameKey.String("name-go"),
+		))
 
 	return sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exp),
@@ -115,7 +116,7 @@ func main() {
 
 	wrappedHandler := otelhttp.NewHandler(mux, "name")
 
-	log.Println("Listening on ", ":8000")
+	log.Println("Listening on http://localhost:8000/name")
 	log.Fatal(http.ListenAndServe(":8000", wrappedHandler))
 }
 

--- a/golang/year-service/main.go
+++ b/golang/year-service/main.go
@@ -64,11 +64,12 @@ func newExporter(ctx context.Context) (*otlptrace.Exporter, error) {
 }
 
 func newTraceProvider(exp *otlptrace.Exporter) *sdktrace.TracerProvider {
-	r :=
+	r, _ := resource.Merge(
+		resource.Default(),
 		resource.NewWithAttributes(
 			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("year-go"), // lol no generics
-		)
+			semconv.ServiceNameKey.String("year-go"),
+		))
 
 	return sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exp),
@@ -123,5 +124,6 @@ func main() {
 
 	wrappedHandler := otelhttp.NewHandler(mux, "year")
 
+	log.Println("Listening on http://localhost:6001/year")
 	log.Fatal(http.ListenAndServe(":6001", wrappedHandler))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
This ensures the default SDK attributes are preserved, eg `telemetry.sdk.name` and `telemetry.sdk.version`.

## Short description of the changes
- Merge the default resource with a custom resource that adds the service name in each otel service
- Ensure each service logs it's url it's listening on

