### PR TITLE
Parameterize which language or services run with Tilt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -458,3 +458,6 @@ $RECYCLE.BIN/
 *.direnv/cache/
 .envrc
 .env
+
+# User specific Tilt config
+tilt_config.json

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 nodejs 16.15.0
+poetry 1.1.13

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ It's also possible to run a combination of services in different languages, for 
 tilt up frontend-node message-go name-py year-rb
 ```
 
-To configure a common set of services that are specific to ongoing development, or to override the default option of running all services in go, add a file `tilt_config.json` and specify a group or set of services. This file is ignored by git so it can be developer specific and allows running `tilt up` without having to specify futher arguments.
+To configure a common set of services that are specific to ongoing development, or to override the default option of running all services in go, add a file `tilt_config.json` and specify a group or set of services.
+This file is ignored by git so it can be developer specific and allows running `tilt up` without having to specify further arguments.
+
 
 Example `tilt_config.json` to override go as the default service
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,46 @@ If using Classic Honeycomb, you'll also need a dataset and must include in the O
 There is a `Tiltfile` to run these services on a local host using <https://tilt.dev/>.
 After installing Tilt, running `tilt up` should spin up all of the services.
 
-The default setup runs the go services; comment out `launch_go_frontend()`, `launch_go_message_service()`, etc. and uncomment the language of choice near the bottom of the Tiltfile.
+The default setup runs the go services.
+
+To run services in another supported language, add the language name after the tilt command:
+
+```shell
+tilt up node
+```
+
+List of supported languages
+
+- `go`
+- `py`
+- `rb`
+- `java`
+- `dotnet`
+- `node`
+
+It's also possible to run a combination of services in different languages, for example the following command would run each specific service mentioned along with the required services (collector, redis, curl greeting)
+
+```shell
+tilt up frontend-node message-go name-py year-rb
+```
+
+To configure a common set of services that are specific to ongoing development, or to override the default option of running all services in go, add a file `tilt_config.json` and specify a group or set of services. This file is ignored by git so it can be developer specific and allows running `tilt up` without having to specify futher arguments.
+
+Example `tilt_config.json` to override go as the default service
+
+```json
+{
+  "to-run": ["node"]
+}
+```
+
+Example `tilt_config.json` to override the default with multiple services
+
+```json
+{
+  "to-run": ["frontend-node", "message-go", "name-py", "year-rb"]
+}
+```
 
 Once running, `curl localhost:7000/greeting` to get a greeting and a trace!
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -193,33 +193,62 @@ def launch_node_name_service(auto_init=True):
 def launch_node_year_service(auto_init=True):
   launch_node_svc("year-node", dirname="node/year-service", auto_init=auto_init)
 
+
+languages = ["go", "py", "rb", "java", "dotnet", "node"]
+
+config.define_string_list("to-run", args=True)
+cfg = config.parse()
+
+groups = {
+    'node': ['frontend-node', 'message-node', 'name-node', 'year-node'],
+    'go': ['frontend-go', 'message-go', 'name-go', 'year-go']
+}
+
+resources = ['collector', 'redis', 'curl greeting']
+to_run = cfg.get('to-run', []) or ["go"]
+
+for arg in to_run:
+  if arg in groups:
+    resources += groups[arg]
+  else:
+    # also support specifying individual services instead of groups, e.g. `tilt up a b d`
+    resources.append(arg)
+config.set_enabled_resources(resources)
+
+# can we run services programatically?
+
+
+
+
+
+
 # Launch one of each of these types of services. Go services init by default
-# launch_go_frontend()
-# launch_python_frontend()
-# launch_ruby_frontend()
-# launch_java_frontend()
-# launch_dotnet_frontend()
+launch_go_frontend()
+launch_python_frontend()
+launch_ruby_frontend()
+launch_java_frontend()
+launch_dotnet_frontend()
 launch_node_frontend()
 
-# launch_go_message_service()
-# launch_python_message_service()
-# launch_ruby_message_service()
-# launch_java_message_service()
-# launch_dotnet_message_service()
+launch_go_message_service()
+launch_python_message_service()
+launch_ruby_message_service()
+launch_java_message_service()
+launch_dotnet_message_service()
 launch_node_message_service()
 
-# launch_go_name_service()
-# launch_python_name_service()
-# launch_ruby_name_service()
-# launch_java_name_service()
-# launch_dotnet_name_service()
+launch_go_name_service()
+launch_python_name_service()
+launch_ruby_name_service()
+launch_java_name_service()
+launch_dotnet_name_service()
 launch_node_name_service()
 
-# launch_go_year_service()
-# launch_python_year_service()
-# launch_ruby_year_service()
-# launch_java_year_service()
-# launch_dotnet_year_service()
+launch_go_year_service()
+launch_python_year_service()
+launch_ruby_year_service()
+launch_java_year_service()
+launch_dotnet_year_service()
 launch_node_year_service()
 
 ###

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,8 +1,15 @@
 # prints show up in the Tiltfile log so you know what's been run
 print("hello my friends")
 
-# required resources: collector & redis
+# Get list of service to run from command line args supported by Tilt
+config.define_string_list("to-run", args=True)
+cfg = config.parse()
 
+# Resources/groups specified from the command line
+# If none are specified it defaults to the "go" group of services so we don't run all the things
+to_run = cfg.get('to-run', []) or ["go"]
+
+# required resrouces: collector & redis
 docker_compose("./docker-compose.yml")
 
 # curl greeting service, language / ecosystem agnostic
@@ -31,7 +38,8 @@ def launch_go_svc(name, dirname="", flags="", auto_init=True):
         'YEAR_ENDPOINT': 'http://localhost:6001',
         'MESSAGE_ENDPOINT': 'http://localhost:9000',
     }
-    print("About to start {} with command {}".format(name, cmd))
+    if "go" in to_run or name in to_run:
+        print("About to start {} with command {}".format(name, cmd))
     local_resource(name, "", auto_init=auto_init, serve_cmd=cmd, serve_env=env)
 
 
@@ -50,25 +58,42 @@ def launch_go_name_service(auto_init=True):
 def launch_go_year_service(auto_init=True):
     launch_go_svc("year-go", dirname="golang/year-service")
 
+def launch_python_svc(name, dirname, run_cmd, auto_init=True):
+    '''
+    Starts a single Python service.
+
+    Parameters:
+    name: used to display the name of the process in the tilt tab
+    dirname: (optional) directory name in which to run `go run main.go` defaults to 'name'
+    run_cmd: command required to run the service
+    '''
+
+    setup_cmd = "cd {} && poetry install --no-root".format(dirname)
+    serve_cmd = "cd {} && poetry run {}".format(dirname,run_cmd)
+    
+    if "py" in to_run or name in to_run:
+        print("About to start {} with command {}".format(name, serve_cmd))
+    
+    local_resource(name, setup_cmd, auto_init=auto_init, serve_cmd=serve_cmd)
+
 
 def launch_python_frontend(auto_init=True):
-    cmd = "cd python/frontend && poetry install --no-root && poetry run python -m frontend"
-    local_resource("frontend-py", "", auto_init=auto_init, serve_cmd=cmd)
+    launch_python_svc("frontend-py", dirname="python/frontend", run_cmd="python -m frontend", auto_init=auto_init)
 
 
 def launch_python_message_service(auto_init=True):
-    cmd = "cd python/message-service && poetry install --no-root && poetry run python -m message_service"
-    local_resource("message-py", "", auto_init=auto_init, serve_cmd=cmd)
+    launch_python_svc("message-py", dirname="python/message-service", run_cmd="python -m message_service", auto_init=auto_init)
+
 
 
 def launch_python_name_service(auto_init=True):
-    cmd = "cd python/name-service && poetry install --no-root && poetry run flask run"
-    local_resource("name-py", "", auto_init=auto_init, serve_cmd=cmd)
+    launch_python_svc("name-py", dirname="python/name-service", run_cmd="flask run", auto_init=auto_init)
+
 
 
 def launch_python_year_service(auto_init=True):
-    cmd = "cd python/year-service && poetry install --no-root && poetry run yearservice/manage.py runserver 127.0.0.1:6001"
-    local_resource("year-py", "", auto_init=auto_init, serve_cmd=cmd)
+    launch_python_svc("year-py", dirname="python/year-service", run_cmd="yearservice/manage.py runserver 127.0.0.1:6001", auto_init=auto_init)
+
 
 def launch_ruby_svc(name, dirname, run_cmd, auto_init=True):
     '''
@@ -77,7 +102,7 @@ def launch_ruby_svc(name, dirname, run_cmd, auto_init=True):
     Parameters:
     name: used to display the name of the process in the tilt tab
     dirname: (optional) directory name in which to run `go run main.go` defaults to 'name'
-    flags: (optional) any additional flags to add to the command line
+    run_cmd: command required to run the service
     '''
 
     env = {
@@ -88,7 +113,10 @@ def launch_ruby_svc(name, dirname, run_cmd, auto_init=True):
     }
     setup_cmd = "cd {} && bundle install".format(dirname)
     serve_cmd = "cd {} && bundle exec {}".format(dirname,run_cmd)
-    print("About to start {} with command {}".format(name, serve_cmd))
+    
+    if "rb" in to_run or name in to_run:
+        print("About to start {} with command {}".format(name, serve_cmd))
+    
     local_resource(name, setup_cmd, env=env, auto_init=auto_init, serve_cmd=serve_cmd, serve_env=env)
 
 def launch_ruby_frontend(auto_init=True):
@@ -121,7 +149,9 @@ def launch_java_svc(name, dirname="", flags="", auto_init=True):
         dirname if dirname else name,
         flags if flags else ""
     )
-    print("About to start {} with command {}".format(name, cmd))
+    if "java" in to_run or name in to_run:
+        print("About to start {} with command {}".format(name, cmd))
+
     local_resource(name, "", auto_init=auto_init, serve_cmd=cmd, serve_env=env)
 
 def launch_java_frontend(auto_init=True):
@@ -150,7 +180,10 @@ def launch_dotnet_svc(name, dirname="", flags="", auto_init=True):
         dirname if dirname else name,
         flags if flags else ""
     )
-    print("About to start {} with command {}".format(name, cmd))
+
+    if "dotnet" in to_run or name in to_run:
+        print("About to start {} with command {}".format(name, cmd))
+
     local_resource(name, "", auto_init=auto_init, serve_cmd=cmd)
 
 def launch_dotnet_frontend(auto_init=True):
@@ -181,7 +214,9 @@ def launch_node_svc(name, dirname="", flags="", auto_init=True):
         dirname if dirname else name,
         flags if flags else ""
     )
-    print("About to start {} with command {}".format(name, cmd))
+    if "node" in to_run or name in to_run:
+        print("About to start {} with command {}".format(name, cmd))
+
     local_resource(name, "", auto_init=auto_init, serve_cmd=cmd, serve_env=env)
 
 def launch_node_frontend(auto_init=True):
@@ -225,10 +260,6 @@ launch_ruby_year_service()
 launch_java_year_service()
 launch_dotnet_year_service()
 launch_node_year_service()
- 
-# Get list of service to run from command line args supported by Tilt
-config.define_string_list("to-run", args=True)
-cfg = config.parse()
 
 # Create map of "groups" of services to commonly run together (e.g. all node services)
 supported_languages = ["go", "py", "rb", "java", "dotnet", "node"]
@@ -243,10 +274,6 @@ groups = { i: append_lang(i) for i in supported_languages }
 
 # Common resources we always want to run
 resources = ['collector', 'redis', 'curl greeting']
-
-# Resources/groups specified from the command line
-# If none are specified it defaults to the "go" group of services so we don't run all the things
-to_run = cfg.get('to-run', []) or ["go"]
 
 # Create the final list of services to run
 for arg in to_run:

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,7 +1,8 @@
 # prints show up in the Tiltfile log so you know what's been run
 print("hello my friends")
 
-# required resrouces: collector & redis
+# required resources: collector & redis
+
 docker_compose("./docker-compose.yml")
 
 # curl greeting service, language / ecosystem agnostic

--- a/node/.gitignore
+++ b/node/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+tilt_config.json


### PR DESCRIPTION
## 🤔 Which problem is this PR solving?
Currently when running EGS, if you want to run an app that isn't the default language, you have to go into the Tiltfile and manually edit it to run the app in the language ecosystem you'd like. There is [Tilt support for running specific services / groups of services](https://docs.tilt.dev/tiltfile_config.html#run-a-defined-set-of-services) so it's possible to parameterize this without changing very much 🎉 . 

## 📝 Short description of the changes
- Updated the Tiltfile to run all services instead of commenting out some of them. This looks 👻 scary 👻  but it's just there so that all the resources can be registered to Tilt, we won't be running all of them.
- Added a group of services that should always run (`collector`, `redis`, `curl greeting`)
- Added groups of services that are common to run together (`go`, `py`, `rb`, `java`, `dotnet`, `node`)
- Added a default that if no services or groups of services are specified, `go` is the default group of services that runs
- Added `tilt_config.json` to `.gitignore` so that folks can have config specific to them that lives on their machines (e.g. I can set my default to node without it affecting anyone else).
- Updated the README to add instructions for how to run services with Tilt
**Added after code review**
- Conditionals in the `launch_<lang>_svc` functions to only print out that those services are launching if they are specified in the group
- Added a `launch_py_svc` function to keep things consistent with the rest of the languages 

## 🧪 Testing
- [x] Running `tilt up` without any config set in `tilt_config.json` should launch `go` services
- [x] Running `tilt up <group>` should launch the correct group of services for `go`, `py`, `rb`, `java`, `dotnet`, `node`
- [x] Running `tilt up frontend-go message-node` should launch the frontend go service and the message node service
- [x] Running `tilt up <nonexistent-service>` shows an error message when Tilt launches in the browser that says it  does not recognize that service
- [x] Running `tilt up` with `node` specified in `tilt_config.json` should launch `node` services
- [x] Running `tilt up rb` with `node` specified in `tilt_config.json` should launch `rb` services
**Tested after code review**
- [x] Logs for which services are starting only show for the services/groups specified
- [x] Python services launch correctly and send data to Honeycomb

## 🐰 Other approaches that didn't work out
- Env variables & command line args didn't make sense once I found that Tilt supports running specific services and groups of services easily
- I thought about finding a way to iterate over languages and services to launch each service and language function but there were subtle enough differences between each function that it would have been a rabbit hole not worth going down but if anyone feels strongly about it I'm happy to revisit it!



