### PR TITLE
maint: update java versions

### DIFF
--- a/java/frontend/Dockerfile
+++ b/java/frontend/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:7.0.1-jdk11 AS build
 WORKDIR /home/gradle/
 RUN mkdir ./libs
-ENV OTEL_AGENT_VER=1.5.3
+ENV OTEL_AGENT_VER=1.21.0
 ENV JAVA_AGENT=opentelemetry-javaagent.jar
 ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_AGENT_VER}/${JAVA_AGENT} ./libs
 COPY --chown=gradle:gradle *.gradle ./
@@ -10,7 +10,7 @@ RUN gradle bootJar --no-daemon
 
 FROM openjdk:13-jdk-alpine
 VOLUME /tmp
-ENV OTEL_AGENT_VER=1.5.3
+ENV OTEL_AGENT_VER=1.21.0
 ENV JAVA_AGENT=opentelemetry-javaagent.jar
 ENV JAVA_TOOL_OPTIONS=-javaagent:${JAVA_AGENT}
 COPY --from=build /home/gradle/libs/${JAVA_AGENT} ./${JAVA_AGENT}

--- a/java/frontend/build.gradle
+++ b/java/frontend/build.gradle
@@ -9,8 +9,8 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 ext {
-    otelVersion = '1.12.0'
-    otelAgentVersion = '1.11.1'
+    otelVersion = '1.21.0'
+    otelAgentVersion = '1.21.0'
 }
 
 configurations {
@@ -24,7 +24,7 @@ repositories {
 
 dependencies {
     implementation("io.opentelemetry:opentelemetry-api:${otelVersion}")
-    implementation("io.opentelemetry:opentelemetry-extension-annotations:${otelVersion}")
+    implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:${otelVersion}")
 
     agent "io.opentelemetry.javaagent:opentelemetry-javaagent:${otelAgentVersion}"
 

--- a/java/frontend/src/main/java/io/honeycomb/examples/frontend_java/MessageService.java
+++ b/java/frontend/src/main/java/io/honeycomb/examples/frontend_java/MessageService.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 
 @Component
 public class MessageService {

--- a/java/frontend/src/main/java/io/honeycomb/examples/frontend_java/NameService.java
+++ b/java/frontend/src/main/java/io/honeycomb/examples/frontend_java/NameService.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 
 @Component
 public class NameService {

--- a/java/message-service/Dockerfile
+++ b/java/message-service/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:7.0.1-jdk11 AS build
 WORKDIR /home/gradle/
 RUN mkdir ./libs
-ENV HONEY_OTEL_VER=0.1.1
+ENV HONEY_OTEL_VER=1.4.0
 ENV HONEY_JAVA_AGENT=honeycomb-opentelemetry-javaagent-${HONEY_OTEL_VER}.jar
 ADD https://github.com/honeycombio/honeycomb-opentelemetry-java/releases/download/v${HONEY_OTEL_VER}/${HONEY_JAVA_AGENT} ./libs
 COPY --chown=gradle:gradle *.gradle ./
@@ -10,7 +10,7 @@ RUN gradle bootJar --no-daemon
 
 FROM openjdk:13-jdk-alpine
 VOLUME /tmp
-ENV HONEY_OTEL_VER=0.1.1
+ENV HONEY_OTEL_VER=1.4.0
 ENV HONEY_JAVA_AGENT=honeycomb-opentelemetry-javaagent-${HONEY_OTEL_VER}.jar
 ENV JAVA_TOOL_OPTIONS=-javaagent:${HONEY_JAVA_AGENT}
 COPY --from=build /home/gradle/libs/${HONEY_JAVA_AGENT} ./${HONEY_JAVA_AGENT}

--- a/java/message-service/build.gradle
+++ b/java/message-service/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 ext {
-    distroVersion = '0.10.0'
+    distroVersion = '1.4.0'
 }
 
 configurations {

--- a/java/message-service/src/main/java/io/honeycomb/examples/message/MessageService.java
+++ b/java/message-service/src/main/java/io/honeycomb/examples/message/MessageService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 
 @Component
 public class MessageService {

--- a/java/name-service/Dockerfile
+++ b/java/name-service/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:7.0.1-jdk11 AS build
 WORKDIR /home/gradle/
 RUN mkdir ./libs
-ENV HONEY_OTEL_VER=0.1.1
+ENV HONEY_OTEL_VER=1.4.0
 ENV HONEY_JAVA_AGENT=honeycomb-opentelemetry-javaagent-${HONEY_OTEL_VER}.jar
 ADD https://github.com/honeycombio/honeycomb-opentelemetry-java/releases/download/v${HONEY_OTEL_VER}/${HONEY_JAVA_AGENT} ./libs
 COPY --chown=gradle:gradle *.gradle ./
@@ -10,7 +10,7 @@ RUN gradle bootJar --no-daemon
 
 FROM openjdk:13-jdk-alpine
 VOLUME /tmp
-ENV HONEY_OTEL_VER=0.1.1
+ENV HONEY_OTEL_VER=1.4.0
 ENV HONEY_JAVA_AGENT=honeycomb-opentelemetry-javaagent-${HONEY_OTEL_VER}.jar
 ENV JAVA_TOOL_OPTIONS=-javaagent:${HONEY_JAVA_AGENT}
 COPY --from=build /home/gradle/libs/${HONEY_JAVA_AGENT} ./${HONEY_JAVA_AGENT}

--- a/java/name-service/build.gradle
+++ b/java/name-service/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 ext {
-    distroVersion = '0.10.0'
+    distroVersion = '1.4.0'
 }
 
 configurations {

--- a/java/name-service/src/main/java/io/honeycomb/examples/name/MessageService.java
+++ b/java/name-service/src/main/java/io/honeycomb/examples/name/MessageService.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 
 @Component
 public class MessageService {

--- a/java/name-service/src/main/java/io/honeycomb/examples/name/NameController.java
+++ b/java/name-service/src/main/java/io/honeycomb/examples/name/NameController.java
@@ -7,13 +7,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import io.opentelemetry.api.trace.Tracer;
-
 @RestController
 public class NameController {
-	@Autowired
-	private Tracer tracer;
-
 	@Autowired
 	private NameService nameService;
 

--- a/java/name-service/src/main/java/io/honeycomb/examples/name/NameService.java
+++ b/java/name-service/src/main/java/io/honeycomb/examples/name/NameService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 
 @Component
 public class NameService {

--- a/java/name-service/src/main/java/io/honeycomb/examples/name/YearService.java
+++ b/java/name-service/src/main/java/io/honeycomb/examples/name/YearService.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 
 @Component
 public class YearService {

--- a/java/name-service/src/main/java/io/honeycomb/examples/name/YearService.java
+++ b/java/name-service/src/main/java/io/honeycomb/examples/name/YearService.java
@@ -1,7 +1,6 @@
 package io.honeycomb.examples.name;
 
 import java.io.IOException;
-import java.net.ConnectException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;

--- a/java/year-service/Dockerfile
+++ b/java/year-service/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:7.0.1-jdk11 AS build
 WORKDIR /home/gradle/
 RUN mkdir ./libs
-ENV HONEY_OTEL_VER=0.1.1
+ENV HONEY_OTEL_VER=1.4.0
 ENV HONEY_JAVA_AGENT=honeycomb-opentelemetry-javaagent-${HONEY_OTEL_VER}.jar
 ADD https://github.com/honeycombio/honeycomb-opentelemetry-java/releases/download/v${HONEY_OTEL_VER}/${HONEY_JAVA_AGENT} ./libs
 COPY --chown=gradle:gradle *.gradle ./
@@ -10,7 +10,7 @@ RUN gradle bootJar --no-daemon
 
 FROM openjdk:13-jdk-alpine
 VOLUME /tmp
-ENV HONEY_OTEL_VER=0.1.1
+ENV HONEY_OTEL_VER=1.4.0
 ENV HONEY_JAVA_AGENT=honeycomb-opentelemetry-javaagent-${HONEY_OTEL_VER}.jar
 ENV JAVA_TOOL_OPTIONS=-javaagent:${HONEY_JAVA_AGENT}
 COPY --from=build /home/gradle/libs/${HONEY_JAVA_AGENT} ./${HONEY_JAVA_AGENT}

--- a/java/year-service/build.gradle
+++ b/java/year-service/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 ext {
-    distroVersion = '0.10.0'
+    distroVersion = '1.4.0'
 }
 
 repositories {

--- a/java/year-service/src/main/java/io/honeycomb/examples/javaotlp/YearService.java
+++ b/java/year-service/src/main/java/io/honeycomb/examples/javaotlp/YearService.java
@@ -5,7 +5,7 @@ import java.util.Random;
 import io.opentelemetry.api.OpenTelemetry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;


### PR DESCRIPTION
## Which problem is this PR solving?

- out-of-date java services

## Short description of the changes

- update to latest otel versions (0.21.0) and honeycomb distro version (1.4.0)
- update deps and imports for `@WithSpan` (`opentelemetry-extension-annotations` moved to `opentelemetry-instrumentation-annotations`)
- remove some unused stuff

