### PR TITLE
maint: adding compiled go binaries to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -461,3 +461,9 @@ $RECYCLE.BIN/
 
 # User specific Tilt config
 tilt_config.json
+
+# Go compiled binaries
+golang/frontend/frontend
+golang/message-service/message-service
+golang/name-service/name-service
+golang/year-service/year-service


### PR DESCRIPTION
When running `tilt up go` the compiled binaries show up in git status and are just noise; we shouldn't add them. This change tells git to ignore the compiled go binaries.