### PR TITLE
fix: use a single random number seed for the whole program

### DIFF
--- a/golang/name-service/main.go
+++ b/golang/name-service/main.go
@@ -80,6 +80,9 @@ func newTraceProvider(exp *otlptrace.Exporter) *sdktrace.TracerProvider {
 }
 
 func main() {
+	// initialize the random number generator
+	rand.Seed(time.Now().UnixNano())
+
 	ctx := context.Background()
 
 	exp, err := newExporter(ctx)
@@ -107,7 +110,6 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/name", func(w http.ResponseWriter, r *http.Request) {
-		rand.Seed(time.Now().UnixNano())
 		time.Sleep(time.Duration(rand.Intn(5)) * time.Millisecond)
 		year, _ := getYear(r.Context())
 		names := namesByYear[year]


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Seeding a random number generator is supposed to happen once per program invocation rather than multiple times within the execution of the program. This change moves the rand seed from within the handler to the overall initialization during `main`. 
