### PR TITLE
maint: whitespace changes for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,260 +9,260 @@ updates:
   - package-ecosystem: "nuget"
     directory: "/dotnet"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
+      prefix: "maint"
+      include: "scope"
 # ELIXIR
   - package-ecosystem: "mix"
     directory: "/elixir/frontend"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
-- package-ecosystem: "mix"
+      prefix: "maint"
+      include: "scope"
+  - package-ecosystem: "mix"
     directory: "/elixir/message"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
-- package-ecosystem: "mix"
+      prefix: "maint"
+      include: "scope"
+  - package-ecosystem: "mix"
     directory: "/elixir/name"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
-- package-ecosystem: "mix"
+      prefix: "maint"
+      include: "scope"
+  - package-ecosystem: "mix"
     directory: "/elixir/year"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
+      prefix: "maint"
+      include: "scope"
 # GOLANG
   - package-ecosystem: "gomod"
     directory: "/golang"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
+      prefix: "maint"
+      include: "scope"
 # JAVA
   - package-ecosystem: "gradle"
     directory: "/java/frontend"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
-- package-ecosystem: "gradle"
+      prefix: "maint"
+      include: "scope"
+  - package-ecosystem: "gradle"
     directory: "/java/message-service"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
-- package-ecosystem: "gradle"
+      prefix: "maint"
+      include: "scope"
+  - package-ecosystem: "gradle"
     directory: "/java/name-service"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
-- package-ecosystem: "gradle"
+      prefix: "maint"
+      include: "scope"
+  - package-ecosystem: "gradle"
     directory: "/java/year-service"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
+      prefix: "maint"
+      include: "scope"
 # NODE
   - package-ecosystem: "npm"
     directory: "/node/frontend"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
-- package-ecosystem: "npm"
+      prefix: "maint"
+      include: "scope"
+  - package-ecosystem: "npm"
     directory: "/node/message-service"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
-- package-ecosystem: "npm"
+      prefix: "maint"
+      include: "scope"
+  - package-ecosystem: "npm"
     directory: "/node/name-service"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
-- package-ecosystem: "npm"
+      prefix: "maint"
+      include: "scope"
+  - package-ecosystem: "npm"
     directory: "/node/year-service"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
+      prefix: "maint"
+      include: "scope"
 # PYTHON
   - package-ecosystem: "pip"
     directory: "/python/frontend"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
-- package-ecosystem: "pip"
+      prefix: "maint"
+      include: "scope"
+  - package-ecosystem: "pip"
     directory: "/python/message-service"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
-- package-ecosystem: "pip"
+      prefix: "maint"
+      include: "scope"
+  - package-ecosystem: "pip"
     directory: "/python/name-service"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
-- package-ecosystem: "pip"
+      prefix: "maint"
+      include: "scope"
+  - package-ecosystem: "pip"
     directory: "/python/year-service"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
+      prefix: "maint"
+      include: "scope"
 # RUBY
   - package-ecosystem: "bundler"
     directory: "/ruby/frontend"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
-- package-ecosystem: "bundler"
+      prefix: "maint"
+      include: "scope"
+  - package-ecosystem: "bundler"
     directory: "/ruby/message-service"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
-- package-ecosystem: "bundler"
+      prefix: "maint"
+      include: "scope"
+  - package-ecosystem: "bundler"
     directory: "/ruby/name-service"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
-- package-ecosystem: "bundler"
+      prefix: "maint"
+      include: "scope"
+  - package-ecosystem: "bundler"
     directory: "/ruby/year-service"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
+      prefix: "maint"
+      include: "scope"
 # WEB
   - package-ecosystem: "npm"
     directory: "/web"
     schedule:
-        interval: "monthly"
+      interval: "monthly"
     labels:
-        - "type: dependencies"
+      - "type: dependencies"
     reviewers:
-        - "honeycombio/telemetry-team"
+      - "honeycombio/telemetry-team"
     commit-message:
-        prefix: "maint"
-        include: "scope"
+      prefix: "maint"
+      include: "scope"


### PR DESCRIPTION
## Which problem is this PR solving?

- maybe fixes failing "validate-pr-title" workflow

## Short description of the changes

- There is a workflow for "validate-pr-title" that checks for a PR title prefix that matches those in a list; the dependabots should be prepended with "maint" based on the `dependabot.yml` `commit-message: prefix: "maint"`, but it doesn't work. I'm not sure if it's because of a syntax issue or because of multiple ecosystems that don't allow this to work as expected, so thought I'd update the syntax just in case. Some of the `package-ecosystem` lines were not properly aligned and showing an error in my editor, so I updated those and other whitespace to be consistent 🤷 

If this doesn't work (maybe the multiple ecosystem issue), we can try adding "build" to the [list of prefixes](https://github.com/honeycombio/example-greeting-service/blob/main/.github/workflows/validate-pr-title.yml#L22), or just remove the pr-title-workflow from this repo. I'm open to any of these options. 
