### PR TITLE
maint: dockerize java

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ If using Classic Honeycomb, you'll also need a dataset and must include in the O
 There is a `Tiltfile` to run these services on a local host using <https://tilt.dev/>.
 After installing Tilt, running `tilt up` should spin up all of the services.
 
+**NOTE**: you need to use tilt version 0.32.2+ otherwise you will get an error
+```
+Docker Compose service "frontend-java" has a relative build path: "./frontend"
+```
+
 This tiltfile utilizes [docker](https://docs.docker.com/desktop/install/mac-install/) and docker compose. You can verify they are installed first by checking `docker version` and `docker compose version` 
 
 The default tilt setup runs the go services.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ This tiltfile utilizes [docker](https://docs.docker.com/desktop/install/mac-inst
 
 The default tilt setup runs the go services.
 
+**NOTE**: if you cancel the `tilt up` command, docker resources will remain running. If you then try to start up another set of services, you will get a port collision. Run `tilt down` which will remove any resources started by tilt previously.
+
 To run services in another supported language, add the language name after the tilt command:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The motivating use case is testing trace context header compatibility between Ho
 
 Port and host names are hardcoded.
 
-- Frontend: Port 7007
+- Frontend: Port 7777
 - Name: Port 8000
 - Year: Port 6001
 - Message: Port 9000
@@ -158,7 +158,7 @@ Example `tilt_config.json` to override the default with multiple services
 }
 ```
 
-Once running, `curl localhost:7007/greeting` to get a greeting and a trace!
+Once running, `curl localhost:7777/greeting` to get a greeting and a trace!
 
 ctrl+c to kill the session, and `tilt down` to spin down all services.
 
@@ -170,4 +170,4 @@ To run the browser app inside of `/web` run
 tilt up web node 
 ```
 
-This will start up the browser app as well as all node backend services. The browser app makes requests to `http://localhost:7007/greeting` so there has to be a set of backend services running. It could also be any one of our other supported languages (e.g. `py`, `go` etc.)
+This will start up the browser app as well as all node backend services. The browser app makes requests to `http://localhost:7777/greeting` so there has to be a set of backend services running. It could also be any one of our other supported languages (e.g. `py`, `go` etc.)

--- a/Tiltfile
+++ b/Tiltfile
@@ -10,7 +10,8 @@ cfg = config.parse()
 to_run = cfg.get('to-run', []) or ["go"]
 
 # required resrouces: collector & redis
-docker_compose("./docker-compose.yml")
+# Java services
+docker_compose(["./docker-compose.yml", "./java/docker-compose.yml"])
 
 # curl greeting service, language / ecosystem agnostic
 local_resource(
@@ -138,41 +139,6 @@ def launch_ruby_name_service(auto_init=True):
 def launch_ruby_year_service(auto_init=True):
     launch_ruby_svc("year-rb", "ruby/year-service", "puma --port 6001", auto_init=auto_init)
 
-def launch_java_svc(name, dirname="", flags="", auto_init=True):
-    '''
-    Starts a single Java service.
-
-    Parameters:
-    name: used to display the name of the process in the tilt tab
-    dirname: (optional) directory name in which to run `go run main.go` defaults to 'name'
-    flags: (optional) any additional flags to add to the command line
-    '''
-
-    env = {
-        'SERVICE_NAME': name,
-        'OTEL_SERVICE_NAME': name
-    }
-    cmd = "cd {} && gradle bootRun".format(
-        dirname if dirname else name,
-        flags if flags else ""
-    )
-    if "java" in to_run or name in to_run:
-        print("About to start {} with command {}".format(name, cmd))
-
-    local_resource(name, "", auto_init=auto_init, serve_cmd=cmd, serve_env=env)
-
-def launch_java_frontend(auto_init=True):
-    launch_java_svc("frontend-java", dirname="java/frontend", auto_init=auto_init)
-
-def launch_java_message_service(auto_init=True):
-    launch_java_svc("message-java", dirname="java/message-service", auto_init=auto_init)
-
-def launch_java_name_service(auto_init=True):
-    launch_java_svc("name-java", dirname="java/name-service", auto_init=auto_init)
-
-def launch_java_year_service(auto_init=True):
-    launch_java_svc("year-java", dirname="java/year-service", auto_init=auto_init)
-
 def launch_dotnet_svc(name, dirname="", flags="", auto_init=True):
     '''
     Starts a single .NET service.
@@ -291,11 +257,12 @@ def launch_web_vanillajs_service(auto_init=True):
 
 # Launch all services so that all service resources are registered with Tilt
 
+# Java services use docker
+
 # Server services
 launch_go_frontend()
 launch_python_frontend()
 launch_ruby_frontend()
-launch_java_frontend()
 launch_dotnet_frontend()
 launch_node_frontend()
 launch_elixir_frontend()
@@ -303,7 +270,6 @@ launch_elixir_frontend()
 launch_go_message_service()
 launch_python_message_service()
 launch_ruby_message_service()
-launch_java_message_service()
 launch_dotnet_message_service()
 launch_node_message_service()
 launch_elixir_message_service()
@@ -311,7 +277,6 @@ launch_elixir_message_service()
 launch_go_name_service()
 launch_python_name_service()
 launch_ruby_name_service()
-launch_java_name_service()
 launch_dotnet_name_service()
 launch_node_name_service()
 launch_elixir_name_service()
@@ -319,7 +284,6 @@ launch_elixir_name_service()
 launch_go_year_service()
 launch_python_year_service()
 launch_ruby_year_service()
-launch_java_year_service()
 launch_dotnet_year_service()
 launch_node_year_service()
 launch_elixir_year_service()

--- a/Tiltfile
+++ b/Tiltfile
@@ -16,7 +16,7 @@ docker_compose(["./docker-compose.yml", "./docker-compose.java.yml"])
 # curl greeting service, language / ecosystem agnostic
 local_resource(
   'curl greeting',
-  cmd='curl -s -i localhost:7007/greeting',
+  cmd='curl -s -i localhost:7777/greeting',
   trigger_mode=TRIGGER_MODE_MANUAL,
   auto_init=False)
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -11,7 +11,7 @@ to_run = cfg.get('to-run', []) or ["go"]
 
 # required resrouces: collector & redis
 # Java services
-docker_compose(["./docker-compose.yml", "./java/docker-compose.yml"])
+docker_compose(["./docker-compose.yml", "./docker-compose.java.yml"])
 
 # curl greeting service, language / ecosystem agnostic
 local_resource(

--- a/docker-compose.java.yml
+++ b/docker-compose.java.yml
@@ -21,7 +21,7 @@ services:
       <<: *common-env
       OTEL_SERVICE_NAME: frontend-java
     ports:
-      - 7007:7007
+      - 7777:7777
 
   message-java:
     build: ./java/message-service

--- a/docker-compose.java.yml
+++ b/docker-compose.java.yml
@@ -1,5 +1,6 @@
 version: "2.4"
 
+# noinspection ComposeUnknownKeys
 x-common-env: &common-env
   HONEYCOMB_API_KEY:
   HONEYCOMB_DATASET:
@@ -14,7 +15,7 @@ x-common-env: &common-env
 
 services:
   frontend-java:
-    build: ./frontend
+    build: ./java/frontend
     image: hnyexample/frontend-java
     environment:
       <<: *common-env
@@ -23,7 +24,7 @@ services:
       - 7007:7007
 
   message-java:
-    build: ./message-service
+    build: ./java/message-service
     image: hnyexample/message-java
     environment:
       <<: *common-env
@@ -32,7 +33,7 @@ services:
       - 9000:9000
 
   name-java:
-    build: ./name-service
+    build: ./java/name-service
     image: hnyexample/name-java
     environment:
       <<: *common-env
@@ -41,7 +42,7 @@ services:
       - 8000:8000
 
   year-java:
-    build: ./year-service
+    build: ./java/year-service
     image: hnyexample/year-java
     environment:
       <<: *common-env

--- a/dotnet/Tiltfile
+++ b/dotnet/Tiltfile
@@ -7,6 +7,6 @@ local_resource(
 
 local_resource(
   'curl greeting',
-  cmd='curl localhost:7007/greeting',
+  cmd='curl localhost:7777/greeting',
   trigger_mode=TRIGGER_MODE_MANUAL,
   auto_init=False)

--- a/dotnet/docker-compose.yml
+++ b/dotnet/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     environment:
       <<: *common-env
     ports:
-      - 7007:7007
+      - 7777:7777
 
   message:
     build: ./message-service

--- a/dotnet/frontend/Dockerfile
+++ b/dotnet/frontend/Dockerfile
@@ -18,7 +18,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0
 WORKDIR /app
 COPY --from=build /app ./
 
-ENV ASPNETCORE_URLS=http://+:7007
+ENV ASPNETCORE_URLS=http://+:7777
 ENV ASPNETCORE_ENVIRONMENT="development"
-EXPOSE 7007
+EXPOSE 7777
 ENTRYPOINT ["dotnet", "frontend.dll"]

--- a/dotnet/frontend/Properties/launchSettings.json
+++ b/dotnet/frontend/Properties/launchSettings.json
@@ -20,7 +20,7 @@
     "frontend": {
       "commandName": "Project",
       "dotnetRunMessages": "true",
-      "applicationUrl": "http://localhost:7007",
+      "applicationUrl": "http://localhost:7777",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -1,7 +1,7 @@
 # Elixir Greeting Services
 
 ## Services
-- Frontend: Service that calls the message, name and year services to create a greeting message served at `localhost:7007/greeting`.
+- Frontend: Service that calls the message, name and year services to create a greeting message served at `localhost:7777/greeting`.
 - Message: Service that chooses a random greeting message.
 - Name: Service that chooses a random name.
 - Year: Service that returns a random year.
@@ -58,7 +58,7 @@ In the top level directory run `tilt up elixir`
 
 ## See it in action
 
-`curl localhost:7007/greeting` for greeting
+`curl localhost:7777/greeting` for greeting
 
 `curl localhost:9000/message` for message only
 

--- a/elixir/docker-compose.yml
+++ b/elixir/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - MESSAGE_ENDPOINT=message:9000
       - OTEL_COLLECTOR_HOST=collector
     ports:
-      - "7007:7007"
+      - "7777:7777"
 
   name:
     build: name

--- a/elixir/frontend/Dockerfile
+++ b/elixir/frontend/Dockerfile
@@ -8,5 +8,5 @@ RUN mix local.rebar --force
 RUN mix deps.get
 RUN mix deps.compile
 
-EXPOSE 7007
+EXPOSE 7777
 CMD mix phx.server

--- a/elixir/frontend/config/dev.exs
+++ b/elixir/frontend/config/dev.exs
@@ -7,7 +7,7 @@ import Config
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :frontend, FrontendWeb.Endpoint,
-  http: [port: 7007],
+  http: [port: 7777],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,

--- a/elixir/frontend/config/prod.secret.exs
+++ b/elixir/frontend/config/prod.secret.exs
@@ -13,7 +13,7 @@ secret_key_base =
 
 config :frontend, FrontendWeb.Endpoint,
   http: [
-    port: String.to_integer(System.get_env("PORT") || "7007"),
+    port: String.to_integer(System.get_env("PORT") || "7777"),
     transport_options: [socket_opts: [:inet6]]
   ],
   secret_key_base: secret_key_base

--- a/golang/docker-compose.yml
+++ b/golang/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       <<: *common-env
       OTEL_SERVICE_NAME: frontend-go
     ports:
-      - 7007:7007
+      - 7777:7777
 
   message:
     build:

--- a/golang/frontend/main.go
+++ b/golang/frontend/main.go
@@ -109,8 +109,8 @@ func main() {
 
 	wrappedHandler := otelhttp.NewHandler(mux, "frontend")
 
-	log.Println("Listening on http://localhost:7007/greeting")
-	log.Fatal(http.ListenAndServe(":7007", wrappedHandler))
+	log.Println("Listening on http://localhost:7777/greeting")
+	log.Fatal(http.ListenAndServe(":7777", wrappedHandler))
 }
 
 func getName(ctx context.Context) string {

--- a/java/docker-compose.yml
+++ b/java/docker-compose.yml
@@ -1,0 +1,50 @@
+version: "2.4"
+
+x-common-env: &common-env
+  HONEYCOMB_API_KEY:
+  HONEYCOMB_DATASET:
+  HONEYCOMB_API:
+  OTEL_EXPORTER_OTLP_ENDPOINT:
+  OTEL_EXPORTER_OTLP_HEADERS:
+  OTEL_RESOURCE_ATTRIBUTES: app.running-in=docker
+  MESSAGE_ENDPOINT: message-java:9000
+  NAME_ENDPOINT: name-java:8000
+  YEAR_ENDPOINT: year-java:6001
+  REDIS_URL: redis
+
+services:
+  frontend-java:
+    build: ./frontend
+    image: hnyexample/frontend-java
+    environment:
+      <<: *common-env
+      OTEL_SERVICE_NAME: frontend-java
+    ports:
+      - 7007:7007
+
+  message-java:
+    build: ./message-service
+    image: hnyexample/message-java
+    environment:
+      <<: *common-env
+      SERVICE_NAME: message-java
+    ports:
+      - 9000:9000
+
+  name-java:
+    build: ./name-service
+    image: hnyexample/name-java
+    environment:
+      <<: *common-env
+      SERVICE_NAME: name-java
+    ports:
+      - 8000:8000
+
+  year-java:
+    build: ./year-service
+    image: hnyexample/year-java
+    environment:
+      <<: *common-env
+      SERVICE_NAME: year-java
+    ports:
+      - 6001:6001

--- a/java/frontend/Dockerfile
+++ b/java/frontend/Dockerfile
@@ -1,18 +1,14 @@
 FROM gradle:7.0.1-jdk11 AS build
 WORKDIR /home/gradle/
 RUN mkdir ./libs
-ENV OTEL_AGENT_VER=1.21.0
-ENV JAVA_AGENT=opentelemetry-javaagent.jar
-ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_AGENT_VER}/${JAVA_AGENT} ./libs
 COPY --chown=gradle:gradle *.gradle ./
 COPY --chown=gradle:gradle ./src ./src
 RUN gradle bootJar --no-daemon
 
 FROM openjdk:13-jdk-alpine
 VOLUME /tmp
-ENV OTEL_AGENT_VER=1.21.0
-ENV JAVA_AGENT=opentelemetry-javaagent.jar
+ENV JAVA_AGENT=otel-javaagent.jar
 ENV JAVA_TOOL_OPTIONS=-javaagent:${JAVA_AGENT}
-COPY --from=build /home/gradle/libs/${JAVA_AGENT} ./${JAVA_AGENT}
+COPY --from=build /home/gradle/agent/${JAVA_AGENT} ./${JAVA_AGENT}
 COPY --from=build /home/gradle/build/libs/*.jar app.jar
 CMD ["java", "-jar", "app.jar"]

--- a/java/frontend/src/main/resources/application.properties
+++ b/java/frontend/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-server.port=7007
+server.port=7777

--- a/java/message-service/Dockerfile
+++ b/java/message-service/Dockerfile
@@ -1,18 +1,14 @@
 FROM gradle:7.0.1-jdk11 AS build
 WORKDIR /home/gradle/
 RUN mkdir ./libs
-ENV HONEY_OTEL_VER=1.4.0
-ENV HONEY_JAVA_AGENT=honeycomb-opentelemetry-javaagent-${HONEY_OTEL_VER}.jar
-ADD https://github.com/honeycombio/honeycomb-opentelemetry-java/releases/download/v${HONEY_OTEL_VER}/${HONEY_JAVA_AGENT} ./libs
 COPY --chown=gradle:gradle *.gradle ./
 COPY --chown=gradle:gradle ./src ./src
 RUN gradle bootJar --no-daemon
 
 FROM openjdk:13-jdk-alpine
 VOLUME /tmp
-ENV HONEY_OTEL_VER=1.4.0
-ENV HONEY_JAVA_AGENT=honeycomb-opentelemetry-javaagent-${HONEY_OTEL_VER}.jar
+ENV HONEY_JAVA_AGENT=honey-javaagent.jar
 ENV JAVA_TOOL_OPTIONS=-javaagent:${HONEY_JAVA_AGENT}
-COPY --from=build /home/gradle/libs/${HONEY_JAVA_AGENT} ./${HONEY_JAVA_AGENT}
+COPY --from=build /home/gradle/agent/${HONEY_JAVA_AGENT} ./${HONEY_JAVA_AGENT}
 COPY --from=build /home/gradle/build/libs/*.jar app.jar
 CMD ["java", "-jar", "app.jar"]

--- a/java/name-service/Dockerfile
+++ b/java/name-service/Dockerfile
@@ -1,18 +1,14 @@
 FROM gradle:7.0.1-jdk11 AS build
 WORKDIR /home/gradle/
 RUN mkdir ./libs
-ENV HONEY_OTEL_VER=1.4.0
-ENV HONEY_JAVA_AGENT=honeycomb-opentelemetry-javaagent-${HONEY_OTEL_VER}.jar
-ADD https://github.com/honeycombio/honeycomb-opentelemetry-java/releases/download/v${HONEY_OTEL_VER}/${HONEY_JAVA_AGENT} ./libs
 COPY --chown=gradle:gradle *.gradle ./
 COPY --chown=gradle:gradle ./src ./src
 RUN gradle bootJar --no-daemon
 
 FROM openjdk:13-jdk-alpine
 VOLUME /tmp
-ENV HONEY_OTEL_VER=1.4.0
-ENV HONEY_JAVA_AGENT=honeycomb-opentelemetry-javaagent-${HONEY_OTEL_VER}.jar
+ENV HONEY_JAVA_AGENT=honey-javaagent.jar
 ENV JAVA_TOOL_OPTIONS=-javaagent:${HONEY_JAVA_AGENT}
-COPY --from=build /home/gradle/libs/${HONEY_JAVA_AGENT} ./${HONEY_JAVA_AGENT}
+COPY --from=build /home/gradle/agent/${HONEY_JAVA_AGENT} ./${HONEY_JAVA_AGENT}
 COPY --from=build /home/gradle/build/libs/*.jar app.jar
 CMD ["java", "-jar", "app.jar"]

--- a/java/year-service/Dockerfile
+++ b/java/year-service/Dockerfile
@@ -1,18 +1,11 @@
 FROM gradle:7.0.1-jdk11 AS build
 WORKDIR /home/gradle/
 RUN mkdir ./libs
-ENV HONEY_OTEL_VER=1.4.0
-ENV HONEY_JAVA_AGENT=honeycomb-opentelemetry-javaagent-${HONEY_OTEL_VER}.jar
-ADD https://github.com/honeycombio/honeycomb-opentelemetry-java/releases/download/v${HONEY_OTEL_VER}/${HONEY_JAVA_AGENT} ./libs
 COPY --chown=gradle:gradle *.gradle ./
 COPY --chown=gradle:gradle ./src ./src
 RUN gradle bootJar --no-daemon
 
 FROM openjdk:13-jdk-alpine
 VOLUME /tmp
-ENV HONEY_OTEL_VER=1.4.0
-ENV HONEY_JAVA_AGENT=honeycomb-opentelemetry-javaagent-${HONEY_OTEL_VER}.jar
-ENV JAVA_TOOL_OPTIONS=-javaagent:${HONEY_JAVA_AGENT}
-COPY --from=build /home/gradle/libs/${HONEY_JAVA_AGENT} ./${HONEY_JAVA_AGENT}
 COPY --from=build /home/gradle/build/libs/*.jar app.jar
 CMD ["java", "-jar", "app.jar"]

--- a/node/README.md
+++ b/node/README.md
@@ -39,7 +39,7 @@ In top-level directory run `tilt up node`
 
 ## See it in action
 
-`curl localhost:7007/greeting` for greeting
+`curl localhost:7777/greeting` for greeting
 
 `curl localhost:9000/message` for message only
 

--- a/node/docker-compose.yml
+++ b/node/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - MESSAGE_ENDPOINT=message:9000
       - SERVICE_NAME=node-frontend-service
     ports:
-      - 7007:7007
+      - 7777:7777
 
   message:
     build: message-service

--- a/node/frontend/Dockerfile
+++ b/node/frontend/Dockerfile
@@ -15,5 +15,5 @@ RUN npm install
 # Bundle app source
 COPY . .
 
-EXPOSE 7007
+EXPOSE 7777
 CMD [ "npm", "start" ]

--- a/node/frontend/main.js
+++ b/node/frontend/main.js
@@ -6,7 +6,7 @@ const fetch = require('node-fetch');
 const cors = require('cors');
 
 // Constants
-const PORT = 7007;
+const PORT = 7777;
 const HOST = '0.0.0.0';
 const MESSAGE_ENDPOINT = process.env.MESSAGE_ENDPOINT || 'localhost:9000';
 const NAME_ENDPOINT = process.env.NAME_ENDPOINT || 'localhost:8000';

--- a/python/README.md
+++ b/python/README.md
@@ -21,6 +21,6 @@ In the python directory run `docker-compose up --build`
 In each service directory, run the Docker commands that build and start the service with the corresponding service names and ports.
 
 ` docker build -t frontend .`
-` docker run -dp 7007:7007 frontend`
+` docker run -dp 7777:7777 frontend`
 
 Or however it is you prefer to Docker. :)

--- a/python/docker-compose.yml
+++ b/python/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       <<: *common-env
       OTEL_SERVICE_NAME: frontend-python
     ports:
-      - 7007:7007
+      - 7777:7777
 
   message:
     build: message-service

--- a/python/frontend/Dockerfile
+++ b/python/frontend/Dockerfile
@@ -21,5 +21,5 @@ RUN poetry config virtualenvs.create false \
 
 COPY ./frontend ./frontend
 
-EXPOSE 7007
+EXPOSE 7777
 CMD ["poetry", "run", "python", "-m", "frontend"]

--- a/python/frontend/frontend/__main__.py
+++ b/python/frontend/frontend/__main__.py
@@ -20,4 +20,4 @@ beeline.init(
 
 
 app = HoneyWSGIMiddleware(create_app())
-run_simple('0.0.0.0', 7007, app, use_debugger=True, use_reloader=True)
+run_simple('0.0.0.0', 7777, app, use_debugger=True, use_reloader=True)

--- a/ruby/docker-compose.yml
+++ b/ruby/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     environment:
       <<: *common-env
     ports:
-      - 7007:7007
+      - 7777:7777
 
   message:
     build: ./message-service

--- a/ruby/frontend/Dockerfile
+++ b/ruby/frontend/Dockerfile
@@ -6,5 +6,5 @@ RUN bundle install
 COPY frontend.ru /myapp
 COPY o11y_wrapper.rb /myapp
 
-EXPOSE 7007
+EXPOSE 7777
 CMD [ "bundle", "exec", "rackup", "frontend.ru", "--server", "puma", "--host", "0.0.0.0"]

--- a/ruby/frontend/frontend.ru
+++ b/ruby/frontend/frontend.ru
@@ -122,8 +122,8 @@ end
 
 Rails.application.initialize!
 
-Rack::Server.new(app: FrontendGreetingApp, Port: 7007).start
+Rack::Server.new(app: FrontendGreetingApp, Port: 7777).start
 
 # To run this example run the `rackup` command with this file
 # Example: rackup frontend.ru
-# Navigate to http://localhost:7007/
+# Navigate to http://localhost:7777/

--- a/web/README.md
+++ b/web/README.md
@@ -1,6 +1,6 @@
 # Browser greeting service
 
-A browser app that sends OTel traces to a collector that passes it through to Honeycomb. The browser app makes a request to `http://localhost:7007/greeting` to trace HTTP requests from the frontend through to the backend.
+A browser app that sends OTel traces to a collector that passes it through to Honeycomb. The browser app makes a request to `http://localhost:7777/greeting` to trace HTTP requests from the frontend through to the backend.
 
 ## Running the app
 

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -57,7 +57,7 @@ const updateGreetingContent = async () => {
       ? document.createElement('h1')
       : document.getElementsByTagName('h1')[0];
   try {
-    const greetingContent = await request('http://localhost:7007/greeting');
+    const greetingContent = await request('http://localhost:7777/greeting');
 
     greeting.innerHTML = greetingContent;
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- java services run with tilt were dependent on a locally installed version of gradle, which could be volatile if e.g. a new dependency version in one java service started requiring a new version of gradle
- running services without containers can be hard for new people trying to us EGS (need to have a lot of things installed)

## Short description of the changes

- use docker-compose to run java services in tilt
- change frontend service port to 7777 (latest docker for mac uses port 7007 👿 )

To verify:
- upgrade tilt to v0.32.2 (older versions don't like relative paths for docker compose builds)
- `tilt up java` --> do the greeting
- cancel tilt and `tilt down java` --> all EGS docker containers are stopped

