### PR TITLE
maint: update go auto instrumentation

### DIFF
--- a/go-auto-instrumented/README.md
+++ b/go-auto-instrumented/README.md
@@ -9,10 +9,10 @@ make local docker image for auto-instrumentation agent:
 git clone git@github.com:open-telemetry/opentelemetry-go-instrumentation.git
 # navigate into new repo
 cd opentelemetry-go-instrumentation
-# make docker image called otel-go-agent:v0.1
-make docker-build IMG=otel-go-agent:v0.1
+# make docker image called otel-go-instrumentation:v0.1
+make docker-build IMG=otel-go-instrumentation:v0.1
 # make sure you have it locally
-docker images | grep otel-go-agent
+docker images | grep otel-go-instrumentation
 ```
 
 ## setup
@@ -59,12 +59,7 @@ after buildings things locally...
 kind create cluster
 
 # load locally built docker images into kind
-kind load docker-image frontend-go-auto:local
-kind load docker-image message-go-auto:local
-kind load docker-image name-go-auto:local
-kind load docker-image year-go-auto:local
-kind load docker-image otel-go-agent:v0.1
-kind load docker-image otel/opentelemetry-collector:0.75.0
+kind load docker-image frontend-go-auto:local message-go-auto:local name-go-auto:local year-go-auto:local otel-go-instrumentation:v0.1 otel/opentelemetry-collector:0.75.0
 ```
 
 ## cleanup

--- a/go-auto-instrumented/greetings-instrumented.yaml
+++ b/go-auto-instrumented/greetings-instrumented.yaml
@@ -34,12 +34,12 @@ spec:
           - name: NAME_ENDPOINT
             value: http://name:8000
         - name: frontend-go-instrumentation
-          image: otel-go-agent:v0.1
+          image: otel-go-instrumentation:v0.1
           env:
-          - name: OTEL_TARGET_EXE
+          - name: OTEL_GO_AUTO_TARGET_EXE
             value: /app/frontend
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: otel-collector:4317
+            value: http://otel-collector:4317
           - name: OTEL_SERVICE_NAME
             value: frontend-go-auto
           - name: OTEL_PROPAGATORS
@@ -82,12 +82,12 @@ spec:
           ports:
             - containerPort: 9000
         - name: message-go-instrumentation
-          image: otel-go-agent:v0.1
+          image: otel-go-instrumentation:v0.1
           env:
-          - name: OTEL_TARGET_EXE
+          - name: OTEL_GO_AUTO_TARGET_EXE
             value: /app/message-service
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: otel-collector:4317
+            value: http://otel-collector:4317
           - name: OTEL_SERVICE_NAME
             value: message-go-auto
           - name: OTEL_PROPAGATORS
@@ -134,12 +134,12 @@ spec:
           - name: YEAR_ENDPOINT
             value: http://year:6001
         - name: name-go-instrumentation
-          image: otel-go-agent:v0.1
+          image: otel-go-instrumentation:v0.1
           env:
-          - name: OTEL_TARGET_EXE
+          - name: OTEL_GO_AUTO_TARGET_EXE
             value: /app/name-service
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: otel-collector:4317
+            value: http://otel-collector:4317
           - name: OTEL_SERVICE_NAME
             value: name-go-auto
           - name: OTEL_PROPAGATORS
@@ -182,12 +182,12 @@ spec:
           ports:
             - containerPort: 6001
         - name: year-go-instrumentation
-          image: otel-go-agent:v0.1
+          image: otel-go-instrumentation:v0.1
           env:
-          - name: OTEL_TARGET_EXE
+          - name: OTEL_GO_AUTO_TARGET_EXE
             value: /app/year-service
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: otel-collector:4317
+            value: http://otel-collector:4317
           - name: OTEL_SERVICE_NAME
             value: year-go-auto
           - name: OTEL_PROPAGATORS


### PR DESCRIPTION
## Which problem is this 

- changes made to go auto-instrumentation 

## Short description of the changes

- update target to new name `OTEL_GO_AUTO_TARGET_EXE` (from `OTEL_TARGET_EXE`)
- update image name from `agent` to `instrumentation`
- add `http://` protocol to endpoint
- consolidate kind commands for loading docker images

