### PR TITLE
maint: update go auto-instr with published image

### DIFF
--- a/go-auto-instrumented/README.md
+++ b/go-auto-instrumented/README.md
@@ -1,20 +1,5 @@
 # auto-instrument go services
 
-## temporary start
-
-make local docker image for auto-instrumentation agent:
-
-```sh
-# clone repo
-git clone git@github.com:open-telemetry/opentelemetry-go-instrumentation.git
-# navigate into new repo
-cd opentelemetry-go-instrumentation
-# make docker image called otel-go-instrumentation:v0.1
-make docker-build IMG=otel-go-instrumentation:v0.1
-# make sure you have it locally
-docker images | grep otel-go-instrumentation
-```
-
 ## setup
 
 ```sh

--- a/go-auto-instrumented/greetings-instrumented.yaml
+++ b/go-auto-instrumented/greetings-instrumented.yaml
@@ -34,7 +34,7 @@ spec:
           - name: NAME_ENDPOINT
             value: http://name:8000
         - name: frontend-go-instrumentation
-          image: otel-go-instrumentation:v0.1
+          image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.2.0-alpha
           env:
           - name: OTEL_GO_AUTO_TARGET_EXE
             value: /app/frontend
@@ -82,7 +82,7 @@ spec:
           ports:
             - containerPort: 9000
         - name: message-go-instrumentation
-          image: otel-go-instrumentation:v0.1
+          image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.2.0-alpha
           env:
           - name: OTEL_GO_AUTO_TARGET_EXE
             value: /app/message-service
@@ -134,7 +134,7 @@ spec:
           - name: YEAR_ENDPOINT
             value: http://year:6001
         - name: name-go-instrumentation
-          image: otel-go-instrumentation:v0.1
+          image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.2.0-alpha
           env:
           - name: OTEL_GO_AUTO_TARGET_EXE
             value: /app/name-service
@@ -182,7 +182,7 @@ spec:
           ports:
             - containerPort: 6001
         - name: year-go-instrumentation
-          image: otel-go-instrumentation:v0.1
+          image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.2.0-alpha
           env:
           - name: OTEL_GO_AUTO_TARGET_EXE
             value: /app/year-service


### PR DESCRIPTION
## Short description of the changes

- update to use the new [published artifact v0.2.0-alpha](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pkgs/container/opentelemetry-go-instrumentation%2Fautoinstrumentation-go/90530735?tag=v0.2.0-alpha)!

