### PR TITLE
maint: use arm-friendly jdk docker images

### DIFF
--- a/java/frontend/Dockerfile
+++ b/java/frontend/Dockerfile
@@ -5,7 +5,7 @@ COPY --chown=gradle:gradle *.gradle ./
 COPY --chown=gradle:gradle ./src ./src
 RUN gradle bootJar --no-daemon
 
-FROM openjdk:13-jdk-alpine
+FROM eclipse-temurin:17-jdk
 VOLUME /tmp
 ENV JAVA_AGENT=otel-javaagent.jar
 ENV JAVA_TOOL_OPTIONS=-javaagent:${JAVA_AGENT}

--- a/java/message-service/Dockerfile
+++ b/java/message-service/Dockerfile
@@ -5,7 +5,7 @@ COPY --chown=gradle:gradle *.gradle ./
 COPY --chown=gradle:gradle ./src ./src
 RUN gradle bootJar --no-daemon
 
-FROM openjdk:17-jdk-alpine
+FROM eclipse-temurin:17-jdk
 VOLUME /tmp
 ENV HONEY_JAVA_AGENT=honey-javaagent.jar
 ENV JAVA_TOOL_OPTIONS=-javaagent:${HONEY_JAVA_AGENT}

--- a/java/name-service/Dockerfile
+++ b/java/name-service/Dockerfile
@@ -5,7 +5,7 @@ COPY --chown=gradle:gradle *.gradle ./
 COPY --chown=gradle:gradle ./src ./src
 RUN gradle bootJar --no-daemon
 
-FROM openjdk:13-jdk-alpine
+FROM eclipse-temurin:17-jdk
 VOLUME /tmp
 ENV HONEY_JAVA_AGENT=honey-javaagent.jar
 ENV JAVA_TOOL_OPTIONS=-javaagent:${HONEY_JAVA_AGENT}

--- a/java/year-service/Dockerfile
+++ b/java/year-service/Dockerfile
@@ -5,7 +5,7 @@ COPY --chown=gradle:gradle *.gradle ./
 COPY --chown=gradle:gradle ./src ./src
 RUN gradle bootJar --no-daemon
 
-FROM openjdk:13-jdk-alpine
+FROM eclipse-temurin:17-jdk
 VOLUME /tmp
 COPY --from=build /home/gradle/build/libs/*.jar app.jar
 CMD ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## Which problem is this PR solving?

- trying to use openjdk:*-jdk-alpine results in error `no matching manifest for linux/arm64/v8 in the manifest list entries`

## Short description of the changes

- swap out [openjdk](https://hub.docker.com/_/openjdk) for [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin). I could just use a non-alpine image, but it also shows this is a deprecated image (see [here](https://github.com/docker-library/openjdk/issues/505)) so figured I'd swap out now.
