### PR TITLE
maint: Update go services with newer go version and newer distro

### DIFF
--- a/golang/frontend/Dockerfile
+++ b/golang/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 AS build
+FROM golang:1.20 AS build
 WORKDIR /src
 ENV CGO_ENABLED=0
 

--- a/golang/go.mod
+++ b/golang/go.mod
@@ -4,8 +4,8 @@ go 1.18
 
 require (
 	github.com/honeycombio/beeline-go v1.11.1
-	github.com/honeycombio/honeycomb-opentelemetry-go v0.5.1
-	github.com/honeycombio/otel-launcher-go v1.7.0
+	github.com/honeycombio/honeycomb-opentelemetry-go v0.5.4
+	github.com/honeycombio/otel-config-go v1.8.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.41.1
 	go.opentelemetry.io/otel v1.15.1
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.15.1

--- a/golang/go.sum
+++ b/golang/go.sum
@@ -152,12 +152,12 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/honeycombio/beeline-go v1.11.1 h1:cyrfwgxM32DKzUhZFJ0KLbPkoyf5lHOyn+7GISwEVZQ=
 github.com/honeycombio/beeline-go v1.11.1/go.mod h1:VTUrnK49oSsWme20E+94XTn1qofDYR56drIJ2bRsJBo=
-github.com/honeycombio/honeycomb-opentelemetry-go v0.5.1 h1:8Aa/afcMSZ4/pSVS1n+CrnbOF2uSd2Jr3OmH7t1Nkj0=
-github.com/honeycombio/honeycomb-opentelemetry-go v0.5.1/go.mod h1:vSV/HUZdzO/9HNHa6PJoZ1bkAFmuhyPzb5VIaQu0YXA=
+github.com/honeycombio/honeycomb-opentelemetry-go v0.5.4 h1:yzc6xDHdJM70GjvB6x1nbSqq/m0XquxolSlEWm8gQhU=
+github.com/honeycombio/honeycomb-opentelemetry-go v0.5.4/go.mod h1:/m8B0RtprPrCVV/fJdE/nqgksdpTkfdpP+Xa5pFUyeo=
 github.com/honeycombio/libhoney-go v1.18.0 h1:OYHOP381r3Ea76BhUYeza8PUTMDp8MByoOxDn3qtEq8=
 github.com/honeycombio/libhoney-go v1.18.0/go.mod h1:KwbcXkqUbH20x3MpfSt/kdvlog3FFdEnouqYD3XKXLY=
-github.com/honeycombio/otel-launcher-go v1.7.0 h1:aIBtiEMo8/L2Br1fR5mwk2J32tlkdsqB8bpwlgTImzQ=
-github.com/honeycombio/otel-launcher-go v1.7.0/go.mod h1:mfI1UuyP3sJZ8aatK77WkSH5wb99ehh3TQXkQk0IWhY=
+github.com/honeycombio/otel-config-go v1.8.0 h1:n25rTbhmNgdtUnaCH1q58UqfLbVrLHXc/LT1XNoaQx0=
+github.com/honeycombio/otel-config-go v1.8.0/go.mod h1:uIk49fSruek3HndJBkS8p+3EBuSeajantKWgA61omEo=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=

--- a/golang/message-service/Dockerfile
+++ b/golang/message-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 AS build
+FROM golang:1.20 AS build
 WORKDIR /src
 ENV CGO_ENABLED=0
 

--- a/golang/name-service/Dockerfile
+++ b/golang/name-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 AS build
+FROM golang:1.20 AS build
 WORKDIR /src
 ENV CGO_ENABLED=0
 

--- a/golang/year-service/Dockerfile
+++ b/golang/year-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 AS build
+FROM golang:1.20 AS build
 WORKDIR /src
 ENV CGO_ENABLED=0
 

--- a/golang/year-service/main.go
+++ b/golang/year-service/main.go
@@ -10,7 +10,7 @@ import (
 
 	_ "github.com/honeycombio/honeycomb-opentelemetry-go"
 
-	"github.com/honeycombio/otel-launcher-go/launcher"
+	"github.com/honeycombio/otel-config-go/otelconfig"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -41,7 +41,7 @@ func yearHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	otelShutdown, err := launcher.ConfigureOpenTelemetry()
+	otelShutdown, err := otelconfig.ConfigureOpenTelemetry()
 	if err != nil {
 		log.Fatalf("error setting up OTel SDK - %e", err)
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

- older versions in go services

## Short description of the changes

- update docker images from golang:1.18 -> golang:1.20
- update honeycomb go distro from 0.5.1 -> 0.5.4
- update otel-launcher-go 1.7.0 -> otel-config-go 1.8.0 (name change)
- update usage of launcher/config in year service to new name

