### PR TITLE
maint: support multi-language setup

### DIFF
--- a/docker-compose.dotnet.yml
+++ b/docker-compose.dotnet.yml
@@ -14,13 +14,14 @@ x-common-env: &common-env
   Otlp__ApiKey: ${HONEYCOMB_API_KEY}
   Otlp__Dataset: ${HONEYCOMB_DATASET}
   Otlp__Endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
-  MESSAGE_ENDPOINT: message-dotnet:9000
-  NAME_ENDPOINT: name-dotnet:8000
-  YEAR_ENDPOINT: year-dotnet:6001
+  MESSAGE_ENDPOINT: message-service:9000
+  NAME_ENDPOINT: name-service:8000
+  YEAR_ENDPOINT: year-service:6001
   REDIS_URL: redis
 
 services:
   frontend-dotnet:
+    container_name: frontend-service
     build: ./dotnet/frontend
     image: hnyexample/frontend-dotnet
     environment:
@@ -29,6 +30,7 @@ services:
       - 7777:7777
 
   message-dotnet:
+    container_name: message-service
     build: ./dotnet/message-service
     image: hnyexample/message-dotnet
     environment:
@@ -37,6 +39,7 @@ services:
       - 9000:9000
 
   name-dotnet:
+    container_name: name-service
     build: ./dotnet/name-service
     image: hnyexample/name-dotnet
     environment:
@@ -45,6 +48,7 @@ services:
       - 8000:8000
 
   year-dotnet:
+    container_name: year-service
     build: ./dotnet/year-service
     image: hnyexample/year-dotnet
     environment:

--- a/docker-compose.java.yml
+++ b/docker-compose.java.yml
@@ -8,13 +8,14 @@ x-common-env: &common-env
   OTEL_EXPORTER_OTLP_ENDPOINT:
   OTEL_EXPORTER_OTLP_HEADERS:
   OTEL_RESOURCE_ATTRIBUTES: app.running-in=docker
-  MESSAGE_ENDPOINT: message-java:9000
-  NAME_ENDPOINT: name-java:8000
-  YEAR_ENDPOINT: year-java:6001
+  MESSAGE_ENDPOINT: message-service:9000
+  NAME_ENDPOINT: name-service:8000
+  YEAR_ENDPOINT: year-service:6001
   REDIS_URL: redis
 
 services:
   frontend-java:
+    container_name: frontend-service
     build: ./java/frontend
     image: hnyexample/frontend-java
     environment:
@@ -24,6 +25,7 @@ services:
       - 7777:7777
 
   message-java:
+    container_name: message-service
     build: ./java/message-service
     image: hnyexample/message-java
     environment:
@@ -33,6 +35,7 @@ services:
       - 9000:9000
 
   name-java:
+    container_name: name-service
     build: ./java/name-service
     image: hnyexample/name-java
     environment:
@@ -42,6 +45,7 @@ services:
       - 8000:8000
 
   year-java:
+    container_name: year-service
     build: ./java/year-service
     image: hnyexample/year-java
     environment:

--- a/docker-compose.python.yml
+++ b/docker-compose.python.yml
@@ -8,12 +8,13 @@ x-common-env: &common-env
     OTEL_EXPORTER_OTLP_ENDPOINT:
     OTEL_EXPORTER_OTLP_HEADERS:
     OTEL_RESOURCE_ATTRIBUTES: app.running-in=docker
-    MESSAGE_ENDPOINT: http://message-python:9000
-    NAME_ENDPOINT: http://name-python:8000
-    YEAR_ENDPOINT: http://year-python:6001
+    MESSAGE_ENDPOINT: http://message-service:9000
+    NAME_ENDPOINT: http://name-service:8000
+    YEAR_ENDPOINT: http://year-service:6001
 
 services:
   frontend-python:
+    container_name: frontend-service
     build: ./python/frontend
     image: hnyexample/frontend-python
     environment:
@@ -23,6 +24,7 @@ services:
       - 7777:7777
 
   message-python:
+    container_name: message-service
     build: ./python/message-service
     image: hnyexample/message-python
     environment:
@@ -32,6 +34,7 @@ services:
       - 9000:9000
 
   name-python:
+    container_name: name-service
     build: ./python/name-service
     image: hnyexample/name-python
     environment:
@@ -41,6 +44,7 @@ services:
       - 8000:8000
 
   year-python:
+    container_name: year-service
     build: ./python/year-service
     image: hnyexample/year-python
     environment:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- we cannot start a variety of services in different languages and have them talk to each other, because the URLs use language-specific service names

## Short description of the changes

- use the same container name for analogous services across languages
- we need to keep the service names language-specific, because that's how we tell tilt to run a particular language

## How to verify

- `tilt up frontend-java message-dotnet name-python year-java`
- get a greeting
- observe a trace that spans multiple language services

