### PR TITLE
fix: python year service

### DIFF
--- a/python/year-service/yearservice/yearservice/settings.py
+++ b/python/year-service/yearservice/yearservice/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'fdcn%etfos=f+l-$fsg69k14k3#2jh*i%=8#g)6*ry=_nyoc(q'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['127.0.0.1', 'localhost', 'year-python']
+ALLOWED_HOSTS = ['127.0.0.1', 'localhost', 'year-service']
 
 
 # Application definition


### PR DESCRIPTION

<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Year service is blocking connections because it has a list of allowed hosts.

Follow-up to #628 hostname is now year-service.
