### PR TITLE
maint: update go-instrumentation image

### DIFF
--- a/go-auto-instrumented/greetings-instrumented.yaml
+++ b/go-auto-instrumented/greetings-instrumented.yaml
@@ -34,7 +34,7 @@ spec:
           - name: NAME_ENDPOINT
             value: http://name:8000
         - name: frontend-go-instrumentation
-          image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.2.0-alpha
+          image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.2.2-alpha
           env:
           - name: OTEL_GO_AUTO_TARGET_EXE
             value: /app/frontend
@@ -82,7 +82,7 @@ spec:
           ports:
             - containerPort: 9000
         - name: message-go-instrumentation
-          image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.2.0-alpha
+          image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.2.2-alpha
           env:
           - name: OTEL_GO_AUTO_TARGET_EXE
             value: /app/message-service
@@ -134,7 +134,7 @@ spec:
           - name: YEAR_ENDPOINT
             value: http://year:6001
         - name: name-go-instrumentation
-          image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.2.0-alpha
+          image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.2.2-alpha
           env:
           - name: OTEL_GO_AUTO_TARGET_EXE
             value: /app/name-service
@@ -182,7 +182,7 @@ spec:
           ports:
             - containerPort: 6001
         - name: year-go-instrumentation
-          image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.2.0-alpha
+          image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.2.2-alpha
           env:
           - name: OTEL_GO_AUTO_TARGET_EXE
             value: /app/year-service


### PR DESCRIPTION
## Which problem is this PR solving?

- newer version of go instrumentation available ([release v0.2.2-alpha](https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.2.2-alpha))

## Short description of the changes

- update image from v0.2.0-alpha to v0.2.2-alpha
- This includes context propagation and client instrumentation

Note there are still some kinks to be worked out (it's alpha) but there is at least a trace for frontend-name-year and frontend-message

![frontend-name-year](https://github.com/honeycombio/example-greeting-service/assets/29520003/7dbb95b0-0e81-405b-846d-90211570905a)

![frontend-message](https://github.com/honeycombio/example-greeting-service/assets/29520003/624d0a88-43dc-4f48-b6fa-51fc186b9596)

