### PR TITLE
fix: close new context when using baggage

### DIFF
--- a/java/frontend/src/main/java/io/honeycomb/examples/frontend_java/GreetingController.java
+++ b/java/frontend/src/main/java/io/honeycomb/examples/frontend_java/GreetingController.java
@@ -1,43 +1,43 @@
 package io.honeycomb.examples.frontend_java;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import io.opentelemetry.api.baggage.Baggage;
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.Tracer;
+import java.net.URISyntaxException;
 
 @RestController
 public class GreetingController {
-	@Autowired
-	private NameService nameService;
+    @Autowired
+    private NameService nameService;
 
-	@Autowired
-	private MessageService messageService;
+    @Autowired
+    private MessageService messageService;
 
-	@Autowired
-	private Tracer tracer;
+    @Autowired
+    private Tracer tracer;
 
-	@RequestMapping("/greeting")
-	public String index() throws URISyntaxException, IOException, InterruptedException {
-		String name = nameService.getName();
+    @RequestMapping("/greeting")
+    public String index() throws URISyntaxException {
+        String name = nameService.getName();
+        Span.current().setAttribute("app.username", name);
 
-		Span.current().setAttribute("app.username", name);
-		Baggage.current()
-			.toBuilder()
-			.put("app.username", name)
-			.build()
-			.makeCurrent();
+        try (final Scope ignored = Baggage.current()
+            .toBuilder()
+            .put("app.username", name)
+            .build()
+            .makeCurrent()
+        ) {
+            String message = messageService.getMessage();
 
-		String message = messageService.getMessage();
-
-		Span span = tracer.spanBuilder("🎨 render message ✨").startSpan();
-		String greeting = String.format("Hello, %s, %s", name, message);
-		span.end();
-		return greeting;
-	}
+            Span span = tracer.spanBuilder("🎨 render message ✨").startSpan();
+            String greeting = String.format("Hello, %s, %s", name, message);
+            span.end();
+            return greeting;
+        }
+    }
 }


### PR DESCRIPTION


<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- makeCurrent() creates a closable Scope
- if we don't close it, context can get wonky and mess up span relationships and trace association java otel recommends using try-with-resource block

