### PR TITLE
maint: Update docker-compose.java.yml

### DIFF
--- a/docker-compose.java.yml
+++ b/docker-compose.java.yml
@@ -12,6 +12,7 @@ x-common-env: &common-env
   NAME_ENDPOINT: name-service:8000
   YEAR_ENDPOINT: year-service:6001
   REDIS_URL: redis
+  OTEL_COLLECTOR_HOST: collector
 
 services:
   frontend-java:


### PR DESCRIPTION
## Which problem is this PR solving?
When running the java front end service the following error is thrown because it cannot communicate with the collector.

```
frontend-service  | [otel.javaagent 2024-01-30 21:30:55:358 +0000] [OkHttp https://api.honeycomb.io/...] WARN io.opentelemetry.exporter.internal.grpc.OkHttpGrpcExporter - Failed to export metrics. Server responded with gRPC status code 16. Error message: unknown API key - check your credentials, region, and API URL
```

## Short description of the changes
- Added missing env variable for collector host