### PR TITLE
maint: Update ubuntu image in workflows to latest

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-publish-docker-image:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   build-and-publish-docker-image:
-    runs-on: ubuntu-latest
+    machine:
+      image: ubuntu-2204:2024.01.1
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Which problem is this PR solving?
Older ubuntu images used in our workflows are being marked as deprecated. We need to update to newer ones.

## Short description of the changes
- Update workflows images to use `ubuntu-2204:2024.01.1` image

