### PR TITLE
maint: update golang/year service to be plain otel

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -52,6 +52,8 @@ def launch_go_svc(name, dirname="", flags="", auto_init=True):
         'NAME_ENDPOINT': 'http://localhost:8000',
         'YEAR_ENDPOINT': 'http://localhost:6001',
         'MESSAGE_ENDPOINT': 'http://localhost:9000',
+        'OTEL_EXPORTER_OTLP_ENDPOINT': 'api.honeycomb.io:443',
+        'OTEL_EXPORTER_OTLP_HEADERS': 'x-honeycomb-team=' + os.environ['HONEYCOMB_API_KEY']
     }
     if "go" in to_run or name in to_run:
         print("About to start {} with command {}".format(name, cmd))


### PR DESCRIPTION
## Which problem is this PR solving?
Updates the golang year service to use plain otel SDK.

- Closes https://github.com/honeycombio/example-greeting-service/issues/968

## Short description of the changes
- Updates golang year service to use base otel SDK instead of honeycomb otel distro
- Add missing env vars in tilt file
