### PR TITLE
fix: Revert "maint: Update ubuntu image in workflows to latest"

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -8,8 +8,7 @@ on:
 
 jobs:
   build-and-publish-docker-image:
-    machine:
-      image: ubuntu-2204:2024.01.1
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Reverts honeycombio/example-greeting-service#992

I think this was fine actually before this change. I didn't look closely enough. Also we can probably delete because we don't really use it anymore but let's just fix it for now.