### PR TITLE
feat: add a healthcheck endpoint to frontend-ruby

### DIFF
--- a/ruby/frontend/Dockerfile
+++ b/ruby/frontend/Dockerfile
@@ -7,4 +7,6 @@ COPY frontend.ru /myapp
 COPY o11y_wrapper.rb /myapp
 
 EXPOSE 7777
+
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "curl", "--fail", "http://localhost:7777/up" ]
 CMD [ "bundle", "exec", "rackup", "frontend.ru", "--server", "puma", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Which problem is this PR solving?

- Demonstrate how to ignore endpoints in OTel Ruby instrumentation, particular use case being chatty healthcheck endpoints.

## Short description of the changes

- adds a HEALTHCHECK command to the Dockerfile so that Docker will nag the healthcheck endpoint
- adds OTel instrumentation config to ignore healthcheck endpoint (doesn't generate traces for requests to /up)


